### PR TITLE
build: support Laravel 10-13 and fix dependency resolution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "axazara/bankai",
     "description": "A Laravel Envoy deployment package for streamlined and consistent deployment processes across projects.",
     "type": "library",
-    "homepage": "https://axazaara.com",
+    "homepage": "https://axazara.com",
     "license": "MIT",
     "authors": [
         {
@@ -20,16 +20,16 @@
         "laravel/envoy": "^2.0"
     },
     "require-dev": {
-        "illuminate/contracts": "^9.0 || ^10.0 || ^11.0",
-        "axazara/php-cs": "^0.1",
+        "illuminate/contracts": "^10.0 || ^11.0 || ^12.0 || ^13.0",
+        "axazara/php-cs": "^0.3",
         "insolita/unused-scanner": "^2.4",
-        "nunomaduro/collision": "^6.0",
-        "larastan/larastan": "^2.6",
-        "orchestra/testbench": "^7.29",
+        "nunomaduro/collision": "^7.0 || ^8.0",
+        "larastan/larastan": "^2.9 || ^3.0",
+        "orchestra/testbench": "^8.0 || ^9.0 || ^10.0 || ^11.0",
         "phpstan/extension-installer": "^1.3",
-        "phpstan/phpstan-deprecation-rules": "^1.1",
-        "phpstan/phpstan-phpunit": "^1.3",
-        "phpunit/phpunit": "^9.6 || ^10.0 || ^11.0",
+        "phpstan/phpstan-deprecation-rules": "^1.1 || ^2.0",
+        "phpstan/phpstan-phpunit": "^1.3 || ^2.0",
+        "phpunit/phpunit": "^10.5 || ^11.0",
         "roave/security-advisories": "dev-latest",
         "spatie/laravel-ray": "^1.32"
     },
@@ -43,6 +43,7 @@
     "scripts": {
         "post-autoload-dump": "@php ./vendor/bin/testbench package:discover --ansi",
         "analyse": "vendor/bin/phpstan analyse",
+        "test": "vendor/bin/phpunit",
         "sniff": "vendor/bin/php-cs-fixer fix -vvv --dry-run --show-progress=dots",
         "format": "vendor/bin/php-cs-fixer fix -vv",
         "unused": "vendor/bin/unused_scanner unused-scanner.php"

--- a/src/Console/BankaiInstall.php
+++ b/src/Console/BankaiInstall.php
@@ -35,6 +35,21 @@ final class BankaiInstall extends Command
         $this->info(string: 'Bankai Laravel Package setup successfully.');
     }
 
+    /**
+     * Publish the Envoy file.
+     */
+    public function publishEnvoyFile(): void
+    {
+        $envoyFile = app()->path() . '/../Envoy.blade.php';
+
+        if (! File::exists($envoyFile)) {
+            File::copy(
+                path: __DIR__ . '/Envoy.blade.exemple.php',
+                target: $envoyFile
+            );
+        }
+    }
+
     private function configExists(): bool
     {
         return File::exists(config_path(path: 'bankai.php'));
@@ -59,20 +74,5 @@ final class BankaiInstall extends Command
             $params['--force'] = true;
         }
         $this->call('vendor:publish', $params);
-    }
-
-    /**
-     * Publish the Envoy file.
-     */
-    public function publishEnvoyFile(): void
-    {
-        $envoyFile = app()->path() . '/../Envoy.blade.php';
-
-        if (! File::exists($envoyFile)) {
-            File::copy(
-                path: __DIR__ . '/Envoy.blade.exemple.php',
-                target: $envoyFile
-            );
-        }
     }
 }

--- a/src/Traits/ConfigValidationTrait.php
+++ b/src/Traits/ConfigValidationTrait.php
@@ -22,7 +22,7 @@ trait ConfigValidationTrait
         }
     }
 
-    private function getConfig(string $key): string|null|array
+    private function getConfig(string $key): null|array|string
     {
         return config($key);
     }


### PR DESCRIPTION
## Summary

CI was failing on every branch because `composer install` could not resolve dependencies:

```
orchestra/testbench ^7.29 require laravel/framework ^9.52.x -> laravel/framework[9.x-dev]
roave/security-advisories dev-latest conflicts with laravel/framework 9.x-dev
```

`orchestra/testbench ^7.29` pins Laravel 9, which is EOL — only the unstable `9.x-dev` satisfies testbench's recent constraints, and `roave/security-advisories` conflicts with it. Since the whole job aborts at install, Code Style and PHPStan never run.

### Changes
- Broaden the dev dependencies so Composer resolves a **stable** Laravel (10 through 13, the current latest release):
  - `illuminate/contracts`: `^10 || ^11 || ^12 || ^13`
  - `orchestra/testbench`: `^8 || ^9 || ^10 || ^11`
  - `nunomaduro/collision`: `^7 || ^8`
  - `larastan/larastan`: `^2.9 || ^3.0`
  - `phpunit/phpunit`: `^10.5 || ^11.0`
  - phpstan rule packages allow `^2.0`
- Bump `axazara/php-cs` to `^0.3`, add a `composer test` script, fix the `homepage` typo.
- Apply the project's own code style (ordered union types and class elements) to clear the Code Style job.

### Verification (local)
- `composer update` resolves cleanly on PHP 8.1 (Laravel 10) and PHP 8.4.
- `php-cs-fixer --dry-run` -> no changes.
- `phpstan analyse` -> 0 errors.

This unblocks the pending Dependabot PRs (#7, #8, #9) and #10.