### PR TITLE
fix(envoy): write @error handler body as raw PHP to avoid nested tag

### DIFF
--- a/src/Envoy.blade.php
+++ b/src/Envoy.blade.php
@@ -496,11 +496,9 @@
 @endsuccess
 
 @error
-   @php
-       if (empty($failureMessage)) {
-           $failureMessage = "Task $task failed on the $env environment on $appName. Error message: $error";
-       }
-   @endphp
+   if (empty($failureMessage)) {
+       $failureMessage = "Task $task failed on the $env environment on $appName. Error message: $error";
+   }
 
    @slack($slackWebhookUrl, '', $failureMessage)
 

--- a/tests/EnvoyCompilationTest.php
+++ b/tests/EnvoyCompilationTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Laravel\Envoy\Compiler;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+/**
+ * Guards that the shipped Envoy template compiles to syntactically valid PHP.
+ *
+ * Envoy directives that open a closure (@before, @after, @success, @error,
+ * @finished) leave the PHP context open for their body, so the body must be
+ * written as raw PHP. Wrapping it in @php ... @endphp emits a nested <?php
+ * (and a premature ?>), which is a fatal parse error at deploy time. This was
+ * the "unexpected token <" regression in the @error handler.
+ */
+final class EnvoyCompilationTest extends BaseTestCase
+{
+    private function compiledTemplate(): string
+    {
+        $source = file_get_contents(__DIR__ . '/../src/Envoy.blade.php');
+
+        return (new Compiler())->compile($source);
+    }
+
+    public function test_envoy_template_compiles_to_syntactically_valid_php(): void
+    {
+        $compiled = $this->compiledTemplate();
+
+        $file = tempnam(sys_get_temp_dir(), 'bankai_envoy_') . '.php';
+        file_put_contents($file, $compiled);
+
+        $output = [];
+        $exitCode = 0;
+        exec(escapeshellarg(PHP_BINARY) . ' -l ' . escapeshellarg($file) . ' 2>&1', $output, $exitCode);
+
+        @unlink($file);
+
+        $this->assertSame(
+            0,
+            $exitCode,
+            'Compiled Envoy template is not valid PHP: ' . implode("\n", $output),
+        );
+    }
+
+    public function test_compiled_template_never_nests_php_open_tags(): void
+    {
+        $compiled = $this->compiledTemplate();
+
+        $offset = 0;
+        $open = false;
+
+        while (true) {
+            $nextOpen = strpos($compiled, '<?php', $offset);
+            $nextClose = strpos($compiled, '?>', $offset);
+
+            if ($nextOpen === false && $nextClose === false) {
+                break;
+            }
+
+            if ($nextOpen !== false && ($nextClose === false || $nextOpen < $nextClose)) {
+                $this->assertFalse(
+                    $open,
+                    'Found a nested <?php open tag at offset ' . $nextOpen . '; an Envoy closure body must hold raw PHP, not @php ... @endphp.',
+                );
+                $open = true;
+                $offset = $nextOpen + 5;
+
+                continue;
+            }
+
+            $open = false;
+            $offset = $nextClose + 2;
+        }
+
+        $this->assertFalse($open, 'Compiled template ended with an unterminated <?php block.');
+    }
+}


### PR DESCRIPTION
## Problem

`vendor/bin/envoy run deploy` fails with:

```
ParseError: syntax error, unexpected token "<" ... at Envoy....php:568
```

The `@error` directive compiles (Envoy `Compiler::compileError`) to:

```php
<?php $_vars = get_defined_vars(); $__container->error(function($task) use ($_vars) { extract($_vars, EXTR_SKIP); 
```

It opens `<?php` and **leaves the PHP context open** for the handler body (same as `@before`/`@after`/`@success`/`@finished`). The body therefore must be raw PHP. `@slack` and `echo` are already raw and compile fine inside it.

The handler wrapped its logic in `@php ... @endphp`, which Envoy compiles to a **nested** `<?php` (and a premature `?>`) inside the already-open block:

```php
<?php ... extract($_vars, EXTR_SKIP);
   <?php                       // <-- nested open tag = fatal parse error
       if (empty($failureMessage)) { ... }
   ?>
```

## Fix

Remove the `@php`/`@endphp` wrapper in the `@error` block; the `if (empty($failureMessage)) { ... }` statement now sits directly in the closure body.

## Test

`tests/EnvoyCompilationTest.php` compiles the shipped `src/Envoy.blade.php` via `Laravel\Envoy\Compiler` and asserts:
1. the output is syntactically valid PHP (`php -l`), and
2. it never nests `<?php` open tags.

The first assertion fails on the current template and passes after the fix.

```
OK (12 tests, 298 assertions)
```
`composer sniff` clean, `composer analyse` clean (single-process).