### PR TITLE
fix(envoy): write @error handler body as raw PHP to avoid nested tag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "phpstan/phpstan-deprecation-rules": "^1.1 || ^2.0",
         "phpstan/phpstan-phpunit": "^1.3 || ^2.0",
         "phpunit/phpunit": "^10.5 || ^11.0",
-        "roave/security-advisories": "dev-latest",
         "spatie/laravel-ray": "^1.32"
     },
     "autoload": {

--- a/src/Envoy.blade.php
+++ b/src/Envoy.blade.php
@@ -496,11 +496,9 @@
 @endsuccess
 
 @error
-   @php
-       if (empty($failureMessage)) {
-           $failureMessage = "Task $task failed on the $env environment on $appName. Error message: $error";
-       }
-   @endphp
+   if (empty($failureMessage)) {
+       $failureMessage = "Task $task failed on the $env environment on $appName. Error message: $error";
+   }
 
    @slack($slackWebhookUrl, '', $failureMessage)
 

--- a/tests/EnvoyCompilationTest.php
+++ b/tests/EnvoyCompilationTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Laravel\Envoy\Compiler;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+/**
+ * Guards that the shipped Envoy template compiles to syntactically valid PHP.
+ *
+ * Envoy directives that open a closure (@before, @after, @success, @error,
+ * @finished) leave the PHP context open for their body, so the body must be
+ * written as raw PHP. Wrapping it in @php ... @endphp emits a nested <?php
+ * (and a premature ?>), which is a fatal parse error at deploy time. This was
+ * the "unexpected token <" regression in the @error handler.
+ */
+final class EnvoyCompilationTest extends BaseTestCase
+{
+    private function compiledTemplate(): string
+    {
+        $source = file_get_contents(__DIR__ . '/../src/Envoy.blade.php');
+
+        return (new Compiler())->compile($source);
+    }
+
+    public function test_envoy_template_compiles_to_syntactically_valid_php(): void
+    {
+        $compiled = $this->compiledTemplate();
+
+        $file = tempnam(sys_get_temp_dir(), 'bankai_envoy_') . '.php';
+        file_put_contents($file, $compiled);
+
+        $output = [];
+        $exitCode = 0;
+        exec(escapeshellarg(PHP_BINARY) . ' -l ' . escapeshellarg($file) . ' 2>&1', $output, $exitCode);
+
+        @unlink($file);
+
+        $this->assertSame(
+            0,
+            $exitCode,
+            'Compiled Envoy template is not valid PHP: ' . implode("\n", $output),
+        );
+    }
+
+    public function test_compiled_template_never_nests_php_open_tags(): void
+    {
+        $compiled = $this->compiledTemplate();
+
+        $offset = 0;
+        $open = false;
+
+        while (true) {
+            $nextOpen = strpos($compiled, '<?php', $offset);
+            $nextClose = strpos($compiled, '?>', $offset);
+
+            if ($nextOpen === false && $nextClose === false) {
+                break;
+            }
+
+            if ($nextOpen !== false && ($nextClose === false || $nextOpen < $nextClose)) {
+                $this->assertFalse(
+                    $open,
+                    'Found a nested <?php open tag at offset ' . $nextOpen . '; an Envoy closure body must hold raw PHP, not @php ... @endphp.',
+                );
+                $open = true;
+                $offset = $nextOpen + 5;
+
+                continue;
+            }
+
+            $open = false;
+            $offset = $nextClose + 2;
+        }
+
+        $this->assertFalse($open, 'Compiled template ended with an unterminated <?php block.');
+    }
+}


### PR DESCRIPTION
Ships the deploy hotfix to `main` (triggers a release).

- **fix(envoy)**: the `@error` handler wrapped its body in `@php ... @endphp`, which Envoy compiles to a nested `<?php` inside the already-open error closure, causing `syntax error, unexpected token "<"` on `envoy run deploy`. The body is now raw PHP. Adds `EnvoyCompilationTest` (compiles the template, asserts valid PHP + no nested tags).
- **ci**: drop `roave/security-advisories` (an app-level conflict-only package) that had started blocking the EOL Laravel 10/11 matrix combos at the dependency-install step.

Full matrix green on the source branch (Tests 8.1–8.4 / Laravel 10–13, PHPStan 8.1–8.4, Check Code Style).