### PR TITLE
feat(deploy)!: add artifact deployment strategy, locking, and harden the Envoy pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,21 @@ Customize `config/bankai.php` according to your project's needs.
 return [
     // General deployment settings
     'settings' => [
-        // Git repository to deploy (HTTPS or SSH URL)
+        // Git repository to deploy (clone strategy only). Use an SSH URL with a
+        // read-only deploy key. HTTPS URLs with embedded credentials are rejected;
+        // CI can inject an ephemeral token-bearing URL through the
+        // BANKAI_REPOSITORY_URL environment variable instead.
         'repository_url'    => 'git@github.com:your-org/your-repository.git',
         // Slack Incoming Webhook URL; leave null to disable notifications
-        'slack_webhook_url' => null,
+        'slack_webhook_url' => env('BANKAI_SLACK_WEBHOOK_URL'),
+        // How many releases to keep on the server (the live one included)
+        'releases_to_keep'  => 3,
     ],
 
     // Define your environments, e.g. staging and production
     'environments' => [
         'staging' => [
+            'strategy'         => 'artifact',        // 'artifact' or 'clone', see below
             'ssh_host'         => 'your-host',       // SSH host of the server
             'ssh_user'         => 'your-user',       // SSH user used for deployment
             'url'              => 'https://staging.your-app.com', // Application URL
@@ -106,6 +112,43 @@ return [
     cd "{{ $currentReleasePath }}"
 @endtask
 ```
+
+## Deployment strategies
+
+Bankai supports two ways of getting a release onto the server, selected per
+environment with the `strategy` key.
+
+### `artifact` (recommended)
+
+CI builds the release and uploads a tarball; the server only extracts it. The
+server needs **no Git access, no Composer authentication and no GitHub or
+registry credentials**, and what was tested in CI is exactly what ships.
+
+The contract: upload the tarball to `{path}/artifacts/incoming.tar.gz`, then run
+the deploy. Bankai consumes (deletes) the artifact after extraction.
+
+```shell
+# In CI, after composer install --no-dev and the asset build:
+php artisan bankai:artifact                    # creates release.tar.gz
+scp release.tar.gz user@host:{path}/artifacts/incoming.tar.gz
+vendor/bin/envoy run deploy --env=production
+```
+
+`bankai:artifact` packages the working directory and always excludes `.git`,
+`.github`, `node_modules`, `tests`, `storage`, `.env*` and `auth.json`.
+
+### `clone` (default)
+
+The historical flow: the server clones the repository and runs
+`composer install` itself. Requires:
+
+- an SSH `repository_url` with a **read-only deploy key** installed on the server;
+- a `shared/auth.json` on the server when private Composer packages are used.
+
+For a temporary token-based clone (for example a GitHub App installation token
+minted in CI), set the `BANKAI_REPOSITORY_URL` environment variable on the
+machine running Envoy; it takes precedence over the configured URL and is never
+stored on the server.
 
 ## Deployment
 
@@ -197,24 +240,34 @@ The following variables are available in your tasks:
 
 ## Rollback
 
-Quickly revert to the previous release:
+Quickly revert to the previous release (atomic symlink switch, no maintenance window):
 
 ```shell
 vendor/bin/envoy run deploy:rollback --env={your-environment}
 ```
 
+## Deployment lock
+
+Each deploy takes a lock on the server so two deployments can never interleave.
+If a deployment crashes and leaves the lock behind, release it with:
+
+```shell
+vendor/bin/envoy run deploy:unlock --env={your-environment}
+```
+
 ## Additional commands
 
-- List releases: `vendor/bin/envoy run releases --env={your-environment}`
+- Build a release artifact: `php artisan bankai:artifact`
+- List releases (the live one is marked): `vendor/bin/envoy run releases --env={your-environment}`
 - List backups: `vendor/bin/envoy run backups --env={your-environment}`
 
 ## Zero-downtime deployment mechanics
 
-1. **New release preparation**: Bankai creates a new release in the `releases/` directory.
-2. **Symlink switching**: The `current` symlink is switched atomically to the new release.
-3. **Shared resources**: Consistency across deployments is maintained via the shared directory and files.
-4. **Rollbacks**: Revert to a previous release at any time.
-5. **Cleanup**: Old releases are pruned, keeping the three most recent.
+1. **New release preparation**: Bankai creates a new release in the `releases/` directory (cloned or extracted from the artifact).
+2. **Cache warm-up**: The new release is optimised before going live; the live release's caches and the shared application cache store are never touched.
+3. **Symlink switching**: The `current` symlink is switched atomically to the new release (`ln + rename`).
+4. **Health check**: The application URL is polled (5 attempts) while the previous release is still on disk, so a failing release can be rolled back instantly.
+5. **Cleanup**: Old releases are pruned, keeping the live release and the most recent others (`releases_to_keep`, default 3).
 
 ## Sentry integration
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,9 @@ Edit the shared environment file created during setup. Every release symlinks to
 
 ### Step 3 — Configure Composer authentication
 
+**Clone strategy only.** With the `artifact` strategy the server never runs
+Composer, so no credentials are needed there — skip this step entirely.
+
 Required only if your application pulls **private** Composer packages or registries. Add an `auth.json` file to the shared directory:
 
 ```shell
@@ -253,8 +256,16 @@ vendor/bin/envoy run deploy:rollback --env={your-environment}
 
 ## Deployment lock
 
-Each deploy takes a lock on the server so two deployments can never interleave.
-If a deployment crashes and leaves the lock behind, release it with:
+At the start of every deploy, Bankai atomically creates a lock directory on the
+server (`{path}/.bankai-deploy.lock`). If the lock already exists, the deploy
+aborts immediately with the timestamp of the run holding it. This guarantees two
+deployments can never interleave: without it, two concurrent runs would race on
+`incoming.tar.gz`, migrations and the `current` symlink.
+
+The lock is released at the end of a successful deploy. It is deliberately
+**not** released on failure, because a half-finished deploy left the server in
+a state that deserves a human look. Once you have checked (and rolled back if
+needed), release it with:
 
 ```shell
 vendor/bin/envoy run deploy:unlock --env={your-environment}

--- a/README.md
+++ b/README.md
@@ -120,22 +120,27 @@ environment with the `strategy` key.
 
 ### `artifact` (recommended)
 
-CI builds the release and uploads a tarball; the server only extracts it. The
-server needs **no Git access, no Composer authentication and no GitHub or
-registry credentials**, and what was tested in CI is exactly what ships.
+The machine running Envoy (CI or your laptop) builds the release and uploads a
+tarball; the server only extracts it. The server needs **no Git access, no
+Composer authentication and no GitHub or registry credentials**, and what was
+tested in CI is exactly what ships.
 
-The contract: upload the tarball to `{path}/artifacts/incoming.tar.gz`, then run
-the deploy. Bankai consumes (deletes) the artifact after extraction.
+Everything happens inside one command:
 
 ```shell
-# In CI, after composer install --no-dev and the asset build:
-php artisan bankai:artifact                    # creates release.tar.gz
-scp release.tar.gz user@host:{path}/artifacts/incoming.tar.gz
 vendor/bin/envoy run deploy --env=production
 ```
 
-`bankai:artifact` packages the working directory and always excludes `.git`,
-`.github`, `node_modules`, `tests`, `storage`, `.env*` and `auth.json`.
+Right before extraction, Bankai copies the project to a temporary build
+directory (excluding `.git`, `.github`, `node_modules`, `tests`, `storage`,
+`.env*`, `auth.json` and the local `vendor`), runs
+`composer install --no-dev --optimize-autoloader`, builds front-end assets when
+a `package.json` with a `build` script is present, packs the tarball, uploads
+it to `{path}/artifacts/incoming.tar.gz` over SSH, and the server consumes
+(deletes) it after extraction. Your working directory is never modified.
+
+`php artisan bankai:artifact` is also available to package the working
+directory as-is (same exclusions), for inspection or manual distribution.
 
 ### `clone` (default)
 

--- a/config/bankai.php
+++ b/config/bankai.php
@@ -2,12 +2,18 @@
 
 return [
     'settings' => [
-        // Git repository to deploy. Supports HTTPS and SSH URLs.
+        // Git repository to deploy (clone strategy only). Use an SSH URL with a
+        // read-only deploy key; HTTPS URLs with embedded credentials are rejected.
+        // CI can override this at run time via the BANKAI_REPOSITORY_URL
+        // environment variable (for example with an ephemeral GitHub App token).
         'repository_url'    => 'git@github.com:your-org/your-repository.git',
 
         // Slack Incoming Webhook URL used to post deployment notifications.
         // Leave null to disable Slack notifications.
-        'slack_webhook_url' => null,
+        'slack_webhook_url' => env('BANKAI_SLACK_WEBHOOK_URL'),
+
+        // How many releases to keep on the server (the live one included).
+        'releases_to_keep'  => 3,
     ],
 
     'sentry' => [
@@ -21,6 +27,10 @@ return [
 
     'environments' => [
         'staging' => [
+            // How the release lands on the server:
+            // - 'artifact': CI builds and uploads a tarball; the server needs no Git or Composer access.
+            // - 'clone': the server clones the repository and installs dependencies itself.
+            'strategy'         => 'artifact',
             'ssh_host'         => 'your-host',
             'ssh_user'         => 'your-user',
             'url'              => 'https://staging.your-app.com',
@@ -46,6 +56,7 @@ return [
         ],
 
         'production' => [
+            'strategy'         => 'artifact',
             'ssh_host'         => 'your-host',
             'ssh_user'         => 'your-user',
             'url'              => 'https://your-app.com',

--- a/src/ArtifactBuilder.php
+++ b/src/ArtifactBuilder.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AxaZara\Bankai;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * Builds the release artifact on the machine running Envoy and uploads it to
+ * the server, so `envoy run deploy` is the only command a pipeline needs.
+ *
+ * The build never touches the working directory: the project is copied to a
+ * temporary directory, production dependencies are installed there, front-end
+ * assets are built when present, and the result is packed into a tarball.
+ */
+class ArtifactBuilder
+{
+    /**
+     * Paths that must never ship in a release artifact: VCS data, local
+     * environment files, credentials, tests, and the shared storage directory
+     * (the server symlinks its own).
+     *
+     * @var list<string>
+     */
+    public const EXCLUDED_PATHS = [
+        '.git',
+        '.github',
+        'node_modules',
+        'tests',
+        'storage',
+        '.env',
+        '.env.*',
+        'auth.json',
+    ];
+
+    private const PROCESS_TIMEOUT = 600;
+
+    public static function buildAndUpload(
+        string $sourceDir,
+        string $sshUser,
+        string $sshHost,
+        string $remoteArtifactPath
+    ): void {
+        $builder = new self();
+
+        $tarball = $builder->build($sourceDir);
+
+        try {
+            $builder->upload($tarball, $sshUser, $sshHost, $remoteArtifactPath);
+        } finally {
+            @unlink($tarball);
+        }
+    }
+
+    public function build(string $sourceDir): string
+    {
+        $buildDir = sys_get_temp_dir() . '/bankai-build-' . uniqid();
+        $tarball = sys_get_temp_dir() . '/bankai-artifact-' . uniqid() . '.tar.gz';
+
+        mkdir($buildDir, 0755, true);
+
+        try {
+            echo "Copying the project to the build directory\n";
+            $this->copyProject($sourceDir, $buildDir);
+
+            echo "Installing production dependencies\n";
+            $this->runOrFail(
+                ['composer', 'install', '--no-dev', '--prefer-dist', '--optimize-autoloader', '--no-progress', '--no-interaction'],
+                $buildDir
+            );
+
+            $this->buildAssets($buildDir);
+
+            echo "Packing the release artifact\n";
+            $this->runOrFail(
+                ['tar', '--exclude=./node_modules', '-czf', $tarball, '.'],
+                $buildDir
+            );
+
+            return $tarball;
+        } finally {
+            $this->removeDirectory($buildDir);
+        }
+    }
+
+    public function upload(string $tarball, string $sshUser, string $sshHost, string $remoteArtifactPath): void
+    {
+        echo "Uploading the release artifact to {$sshHost}\n";
+
+        $this->runOrFail(
+            ['scp', '-q', $tarball, "{$sshUser}@{$sshHost}:{$remoteArtifactPath}"],
+            null
+        );
+
+        echo "Artifact uploaded\n";
+    }
+
+    private function copyProject(string $sourceDir, string $buildDir): void
+    {
+        $command = ['rsync', '-a'];
+
+        foreach (self::EXCLUDED_PATHS as $excludedPath) {
+            $command[] = "--exclude=/{$excludedPath}";
+        }
+
+        // The vendor directory is rebuilt from the lock file inside the build
+        // directory, so the (dev-polluted) local one is never copied.
+        $command[] = '--exclude=/vendor';
+        $command[] = rtrim($sourceDir, '/') . '/';
+        $command[] = $buildDir . '/';
+
+        $this->runOrFail($command, null);
+    }
+
+    private function buildAssets(string $buildDir): void
+    {
+        if (! file_exists("{$buildDir}/package.json")) {
+            return;
+        }
+
+        echo "Installing front-end dependencies\n";
+
+        if (file_exists("{$buildDir}/yarn.lock")) {
+            $this->runOrFail(['yarn', 'install', '--immutable'], $buildDir);
+            $buildCommand = ['yarn', 'build'];
+        } elseif (file_exists("{$buildDir}/package-lock.json")) {
+            $this->runOrFail(['npm', 'ci'], $buildDir);
+            $buildCommand = ['npm', 'run', 'build'];
+        } else {
+            $this->runOrFail(['npm', 'install'], $buildDir);
+            $buildCommand = ['npm', 'run', 'build'];
+        }
+
+        $packageJson = json_decode((string) file_get_contents("{$buildDir}/package.json"), true);
+
+        if (isset($packageJson['scripts']['build'])) {
+            echo "Building front-end assets\n";
+            $this->runOrFail($buildCommand, $buildDir);
+        }
+    }
+
+    private function runOrFail(array $command, ?string $workingDir): void
+    {
+        $process = new Process($command, $workingDir, null, null, self::PROCESS_TIMEOUT);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            throw new \RuntimeException(sprintf(
+                "Command '%s' failed:\n%s",
+                implode(' ', $command),
+                trim($process->getErrorOutput() . "\n" . $process->getOutput())
+            ));
+        }
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        (new Process(['rm', '-rf', $directory]))->run();
+    }
+}

--- a/src/Console/BankaiArtifact.php
+++ b/src/Console/BankaiArtifact.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AxaZara\Bankai\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Process\Process;
+
+final class BankaiArtifact extends Command
+{
+    /**
+     * Paths that must never ship in a release artifact: VCS data, local
+     * environment files, credentials, tests, and the shared storage directory
+     * (the server symlinks its own).
+     *
+     * @var list<string>
+     */
+    private const EXCLUDED_PATHS = [
+        './.git',
+        './.github',
+        './node_modules',
+        './tests',
+        './storage',
+        './.env',
+        './.env.*',
+        './auth.json',
+    ];
+
+    protected $signature = 'bankai:artifact
+        {--output=release.tar.gz : Path of the tarball to create}';
+
+    protected $description = 'Package the application into a deployable release artifact (run after composer install --no-dev and the asset build)';
+
+    public function handle(): int
+    {
+        $output = (string) $this->option('output');
+
+        $command = ['tar'];
+
+        foreach (self::EXCLUDED_PATHS as $excludedPath) {
+            $command[] = "--exclude={$excludedPath}";
+        }
+
+        $command[] = '--exclude=' . $this->outputAsExclusion($output);
+        $command[] = '-czf';
+        $command[] = $output;
+        $command[] = '.';
+
+        $process = new Process($command, base_path(), null, null, 600);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            $this->error('Artifact build failed: ' . trim($process->getErrorOutput()));
+
+            return self::FAILURE;
+        }
+
+        $size = round(filesize($this->absoluteOutput($output)) / 1_048_576, 1);
+
+        $this->info("Artifact created at {$output} ({$size} MB).");
+        $this->line('Upload it to the server before running the deploy, for example:');
+        $this->line('  scp ' . $output . ' <user>@<host>:<deploy-path>/artifacts/incoming.tar.gz');
+
+        return self::SUCCESS;
+    }
+
+    private function outputAsExclusion(string $output): string
+    {
+        return str_starts_with($output, '/') ? $output : './' . ltrim($output, './');
+    }
+
+    private function absoluteOutput(string $output): string
+    {
+        return str_starts_with($output, '/') ? $output : base_path($output);
+    }
+}

--- a/src/Console/BankaiArtifact.php
+++ b/src/Console/BankaiArtifact.php
@@ -4,29 +4,12 @@ declare(strict_types=1);
 
 namespace AxaZara\Bankai\Console;
 
+use AxaZara\Bankai\ArtifactBuilder;
 use Illuminate\Console\Command;
 use Symfony\Component\Process\Process;
 
 final class BankaiArtifact extends Command
 {
-    /**
-     * Paths that must never ship in a release artifact: VCS data, local
-     * environment files, credentials, tests, and the shared storage directory
-     * (the server symlinks its own).
-     *
-     * @var list<string>
-     */
-    private const EXCLUDED_PATHS = [
-        './.git',
-        './.github',
-        './node_modules',
-        './tests',
-        './storage',
-        './.env',
-        './.env.*',
-        './auth.json',
-    ];
-
     protected $signature = 'bankai:artifact
         {--output=release.tar.gz : Path of the tarball to create}';
 
@@ -38,8 +21,8 @@ final class BankaiArtifact extends Command
 
         $command = ['tar'];
 
-        foreach (self::EXCLUDED_PATHS as $excludedPath) {
-            $command[] = "--exclude={$excludedPath}";
+        foreach (ArtifactBuilder::EXCLUDED_PATHS as $excludedPath) {
+            $command[] = "--exclude=./{$excludedPath}";
         }
 
         $command[] = '--exclude=' . $this->outputAsExclusion($output);

--- a/src/DeploymentConfig.php
+++ b/src/DeploymentConfig.php
@@ -3,6 +3,7 @@
 namespace AxaZara\Bankai;
 
 use AxaZara\Bankai\Traits\ConfigValidationTrait;
+use Illuminate\Support\Env;
 
 class DeploymentConfig
 {
@@ -96,7 +97,7 @@ class DeploymentConfig
      */
     private function resolveRepositoryUrl(): ?string
     {
-        $override = env('BANKAI_REPOSITORY_URL');
+        $override = Env::get('BANKAI_REPOSITORY_URL');
 
         if (is_string($override) && $override !== '') {
             return $override;

--- a/src/DeploymentConfig.php
+++ b/src/DeploymentConfig.php
@@ -8,10 +8,30 @@ class DeploymentConfig
 {
     use ConfigValidationTrait;
 
+    public const STRATEGY_CLONE = 'clone';
+
+    public const STRATEGY_ARTIFACT = 'artifact';
+
+    public const DEFAULT_RELEASES_TO_KEEP = 3;
+
+    private readonly string $strategy;
+
+    private readonly ?string $repositoryUrl;
+
     public function __construct(
         public readonly string $env
     ) {
         $this->validateConfiguration(environment: $env);
+
+        $this->strategy = $this->getConfig("bankai.environments.{$env}.strategy") ?? self::STRATEGY_CLONE;
+        $this->repositoryUrl = $this->resolveRepositoryUrl();
+
+        if ($this->strategy === self::STRATEGY_CLONE && ($this->repositoryUrl === null || $this->repositoryUrl === '')) {
+            throw new \RuntimeException(
+                "The '{$env}' environment uses the 'clone' strategy but no repository URL is configured. " .
+                "Set 'bankai.settings.repository_url' or the BANKAI_REPOSITORY_URL environment variable."
+            );
+        }
     }
 
     public function extractVariables(): array
@@ -32,7 +52,8 @@ class DeploymentConfig
         string $release
     ): array {
         return [
-            'repositoryUrl'      => $this->getConfig('bankai.settings.repository_url'),
+            'strategy'           => $this->strategy,
+            'repositoryUrl'      => $this->repositoryUrl,
             'slackWebhookUrl'    => $this->getConfig('bankai.settings.slack_webhook_url'),
             'appName'            => config('app.name'),
             'branch'             => $environmentSettings['branch'],
@@ -51,6 +72,7 @@ class DeploymentConfig
             'octaneReload'       => $environmentSettings['octane']['reload'],
             'octaneServer'       => $environmentSettings['octane']['server'],
             'horizonTerminate'   => $environmentSettings['horizon']['terminate'],
+            'releasesToKeep'     => $this->resolveReleasesToKeep(),
             'date'               => date('Y-m-d H:i:s'),
             'release'            => $release,
             'releasePath'        => "{$path}/releases/{$release}",
@@ -58,7 +80,48 @@ class DeploymentConfig
             'sharedPath'         => "{$path}/shared",
             'backupPath'         => "{$path}/backups",
             'currentReleasePath' => "{$path}/current",
+            'artifactsPath'      => "{$path}/artifacts",
+            'artifactPath'       => "{$path}/artifacts/incoming.tar.gz",
+            'deployLockPath'     => "{$path}/.bankai-deploy.lock",
         ];
+    }
+
+    /**
+     * Resolve the repository URL, preferring the BANKAI_REPOSITORY_URL
+     * environment variable so CI can inject an ephemeral, token-bearing URL
+     * (for example a GitHub App installation token) without persisting it.
+     *
+     * A credential embedded in the committed configuration is rejected: HTTP(S)
+     * URLs with a userinfo segment leak secrets into version control and logs.
+     */
+    private function resolveRepositoryUrl(): ?string
+    {
+        $override = env('BANKAI_REPOSITORY_URL');
+
+        if (is_string($override) && $override !== '') {
+            return $override;
+        }
+
+        $configured = $this->getConfig('bankai.settings.repository_url');
+
+        if (is_string($configured) && preg_match('#^https?://[^/@]+@#i', $configured) === 1) {
+            throw new \RuntimeException(
+                'bankai.settings.repository_url must not embed credentials. ' .
+                'Use an SSH deploy key (git@github.com:org/repo.git) or inject an ephemeral ' .
+                'token-bearing URL through the BANKAI_REPOSITORY_URL environment variable.'
+            );
+        }
+
+        return $configured;
+    }
+
+    private function resolveReleasesToKeep(): int
+    {
+        $configured = $this->getConfig('bankai.settings.releases_to_keep');
+
+        return is_numeric($configured) && (int) $configured >= 1
+            ? (int) $configured
+            : self::DEFAULT_RELEASES_TO_KEEP;
     }
 
     private function getSentryVariables(string $release): array

--- a/src/Envoy.blade.php
+++ b/src/Envoy.blade.php
@@ -3,10 +3,10 @@
         *Deployment completed on $appName*
         - App name: $appName
         - Environment: $env
+        - Strategy: $strategy
         - URL: $appUrl
         - Deployment path: $path
         - Current release: $release
-        - Repository: $repositoryUrl
         - Branch: $branch
         - SSH host: $sshHost
         - Date: $date
@@ -14,15 +14,18 @@
 
     $rollbackSuccessMessage = "*$appName* has been rolled back to the previous release.";
 
-    $failureMessage = null;
+    // Slack payloads are JSON-encoded and shell-quoted up front so app names or
+    // messages containing quotes can never break the curl command or the JSON body.
+    $deploymentSuccessPayload = escapeshellarg(json_encode(['text' => $deploymentSuccess]));
+    $rollbackSuccessPayload = escapeshellarg(json_encode(['text' => $rollbackSuccessMessage]));
 @endsetup
 
 @servers([$env => "{$sshUser}@{$sshHost}"])
 
 @story('setup' , ['on' => $env])
-    set:setup_failure_message
     setup:directories
     make:clone_repository
+    make:extract_artifact
     make:link_composer_auth
     make:install_composer_dependencies
     setup:common_files
@@ -33,14 +36,15 @@
 @endstory
 
 @story('deploy' , ['on' => $env])
-    set:deploy_failure_message
     display_info
     check_if_release_exists
+    deploy:acquire_lock
     run:before_deploy
     make:clone_repository
+    make:extract_artifact
     make:link_composer_auth
     make:install_composer_dependencies
-    make:npm_install
+    make:build_assets
     make:symlinks
     make:app_down
     make:migration
@@ -53,8 +57,9 @@
     make:restart_queue
     make:horizon:terminate
     make:reload_octane
-    make:clean_old_release
     make:check_app_health
+    make:clean_old_release
+    deploy:release_lock
     sentry:release
     deploy:complete
 @endstory
@@ -63,6 +68,10 @@
     make:rollback
     run:after_rollback
     rollback:complete
+@endstory
+
+@story('deploy:unlock', ['on' => $env])
+    deploy:force_unlock
 @endstory
 
 @story('backups')
@@ -75,174 +84,253 @@
 
 @task('display_info')
     echo "Deployment information:";
+    echo "- Strategy: {{ $strategy }}";
     echo "- Deployment path: {{ $releasePath }}";
     echo "- Current release: {{ $release }}";
     echo "- Releases path: {{ $releasesPath }}";
     echo "- Shared path: {{ $sharedPath }}";
-    echo "- Repository: {{ $repositoryUrl }}";
-    echo "- Branch: {{ $branch }}";
+    @if ($strategy === 'clone')
+        echo "- Repository: {{ $repositoryUrl }}";
+        echo "- Branch: {{ $branch }}";
+    @else
+        echo "- Artifact: {{ $artifactPath }}";
+    @endif
     echo "- URL: {{ $appUrl }}";
     echo "- Environment: {{ $env }}";
-    echo "- Backup path: {{ $backupPath }}";
-@endtask
-
-@task('set:deploy_failure_message')
-    @php
-        $failureMessage = "
-            *Deployment failed on $appName*
-            - App name: $appName
-            - Environment: $env
-            - Deployment path: $path
-            - Repository: $repositoryUrl
-            - Branch: $branch
-            - SSH host: $sshHost
-            - Date: $date
-        ";
-    @endphp
-
-    true
-@endtask
-
-@task('set:setup_failure_message')
-    @php
-        $failureMessage = "
-            *Project setup failed on $appName*
-            - App name: $appName
-            - Environment: $env
-            - Deployment path: $path
-            - Repository: $repositoryUrl
-            - Branch: $branch
-            - SSH host: $sshHost
-            - Date: $date
-        ";
-    @endphp
-
-    true
+    echo "- Releases kept: {{ $releasesToKeep }}";
 @endtask
 
 @task('setup:directories')
-   # Abort if the release directory already exists to avoid overwriting an existing deployment.
-   if [ -d {{ $releasesPath }} ]; then
-       echo "Release directory already exists on the server. Run 'envoy run deploy' to deploy your application.";
-       echo "If you think this is an error, clean up the deployment folder manually and try again.";
-       exit 1;
+   set -euo pipefail
+
+   # Refuse to run twice: an existing release means the server is already set up.
+   if [ -d "{{ $releasesPath }}" ] && [ -n "$(ls -A "{{ $releasesPath }}" 2>/dev/null)" ]; then
+       echo "Releases already exist on this server. Run 'envoy run deploy' to deploy your application."
+       echo "If you think this is an error, clean up the deployment folder manually and try again."
+       exit 1
    fi
 
-   echo "Creating deployment directories";
+   echo "Creating deployment directories"
 
    mkdir -p "{{ $releasesPath }}"
    mkdir -p "{{ $sharedPath }}"
    mkdir -p "{{ $backupPath }}"
+   mkdir -p "{{ $artifactsPath }}"
 
-   echo "Deployment directories created";
+   echo "Deployment directories created"
+@endtask
+
+@task('deploy:acquire_lock')
+   # mkdir is atomic: it either creates the lock or fails because one exists.
+   if mkdir "{{ $deployLockPath }}" 2>/dev/null; then
+       date '+%Y-%m-%d %H:%M:%S' > "{{ $deployLockPath }}/started_at"
+       echo "Deployment lock acquired"
+   else
+       echo "Another deployment appears to be in progress since $(cat "{{ $deployLockPath }}/started_at" 2>/dev/null || echo 'unknown')."
+       echo "If that deployment crashed, release the lock with: envoy run deploy:unlock --env={{ $env }}"
+       exit 1
+   fi
+@endtask
+
+@task('deploy:release_lock')
+   rm -rf "{{ $deployLockPath }}"
+   echo "Deployment lock released"
+@endtask
+
+@task('deploy:force_unlock')
+   if [ -d "{{ $deployLockPath }}" ]; then
+       rm -rf "{{ $deployLockPath }}"
+       echo "Deployment lock forcibly released"
+   else
+       echo "No deployment lock found, nothing to do"
+   fi
 @endtask
 
 @task('make:clone_repository')
-   echo "Cloning repository";
+   @if ($strategy === 'clone')
+       set -euo pipefail
 
-   cd {{ $releasesPath }}
-   git clone "{{ $repositoryUrl }}" --branch="{{ $branch }}" --depth=1 -q "{{ $release }}"
-   echo "Repository cloned";
+       echo "Cloning repository ({{ $branch }})"
+
+       cd "{{ $releasesPath }}"
+       git clone "{{ $repositoryUrl }}" --branch="{{ $branch }}" --depth=1 --single-branch -q "{{ $release }}"
+
+       echo "Repository cloned"
+   @else
+       echo "Repository clone skipped (artifact strategy)"
+   @endif
+@endtask
+
+@task('make:extract_artifact')
+   @if ($strategy === 'artifact')
+       set -euo pipefail
+
+       if [ ! -s "{{ $artifactPath }}" ]; then
+           echo "No artifact found at {{ $artifactPath }}."
+           echo "Build and upload the release artifact first, for example:"
+           echo "  php artisan bankai:artifact"
+           echo "  scp release.tar.gz {{ $sshUser }}@{{ $sshHost }}:{{ $artifactPath }}"
+           exit 1
+       fi
+
+       echo "Extracting artifact into the new release"
+
+       mkdir -p "{{ $releasePath }}"
+       tar -xzf "{{ $artifactPath }}" -C "{{ $releasePath }}"
+       rm -f "{{ $artifactPath }}"
+
+       echo "Artifact extracted and consumed"
+   @else
+       echo "Artifact extraction skipped (clone strategy)"
+   @endif
 @endtask
 
 @task('make:link_composer_auth')
-   # Symlink a shared auth.json (if present) so Composer can authenticate against
-   # private registries and repositories during installation.
-   if [ -f {{ $sharedPath }}/auth.json ]; then
-       ln -sf {{ $sharedPath }}/auth.json {{ $releasePath }}/auth.json
-       echo "Composer auth.json linked from the shared directory";
-   else
-       echo "No shared auth.json found, skipping Composer authentication setup";
-   fi
+   @if ($strategy === 'clone')
+       # Symlink a shared auth.json (if present) so Composer can authenticate against
+       # private registries and repositories during installation.
+       if [ -f "{{ $sharedPath }}/auth.json" ]; then
+           ln -sf "{{ $sharedPath }}/auth.json" "{{ $releasePath }}/auth.json"
+           echo "Composer auth.json linked from the shared directory"
+       else
+           echo "No shared auth.json found, skipping Composer authentication setup"
+       fi
+   @else
+       echo "Composer auth skipped (artifact ships its vendor directory)"
+   @endif
 @endtask
 
 @task('make:install_composer_dependencies')
-   echo "Installing Composer dependencies";
+   @if ($strategy === 'clone')
+       set -euo pipefail
 
-   cd {{ $releasePath }}
-   {{ $composer }} install {{ $composerOptions }} --no-progress
+       echo "Installing Composer dependencies"
 
-   echo "Composer dependencies installed";
+       cd "{{ $releasePath }}"
+       {{ $composer }} install {{ $composerOptions }} --no-progress
+
+       echo "Composer dependencies installed"
+   @else
+       echo "Composer install skipped (artifact ships its vendor directory)"
+   @endif
 @endtask
 
-@task('make:npm_install')
-   cd {{ $releasePath }}
+@task('make:build_assets')
+   @if ($strategy === 'clone')
+       set -euo pipefail
 
-   if [ -f "package.json" ]; then
-       echo "Running npm install"
+       cd "{{ $releasePath }}"
 
-       if [ -f "yarn.lock" ]; then
-           yarn install --immutable
+       if [ ! -f package.json ]; then
+           echo "Asset build skipped, no package.json found"
        else
-           npm install
-       fi
+           echo "Installing front-end dependencies"
 
-       echo "Npm install complete"
-   else
-       echo "Npm install skipped, no package.json file found"
-   fi
+           if [ -f yarn.lock ]; then
+               yarn install --immutable
+           elif [ -f package-lock.json ]; then
+               npm ci
+           else
+               npm install
+           fi
+
+           if grep -q '"build"' package.json; then
+               echo "Building assets"
+
+               if [ -f yarn.lock ]; then
+                   yarn build
+               else
+                   npm run build
+               fi
+
+               echo "Assets built"
+           else
+               echo "No build script defined, skipping asset build"
+           fi
+       fi
+   @else
+       echo "Asset build skipped (artifact ships built assets)"
+   @endif
 @endtask
 
 @task('setup:common_files')
-   echo "Copying common files";
+   set -euo pipefail
 
-   mv {{ $releasePath }}/storage {{ $sharedPath }}/storage
-   echo "Storage moved to the shared directory";
+   echo "Copying common files"
 
-   # Seed the shared .env from the repository's .env.example
-   cp {{ $releasePath }}/.env.example {{ $sharedPath }}/.env
-   echo "Shared .env created from .env.example";
+   if [ -d "{{ $sharedPath }}/storage" ]; then
+       echo "Shared storage already exists, left untouched"
+       rm -rf "{{ $releasePath }}/storage"
+   elif [ -d "{{ $releasePath }}/storage" ]; then
+       mv "{{ $releasePath }}/storage" "{{ $sharedPath }}/storage"
+       echo "Storage moved to the shared directory"
+   else
+       mkdir -p "{{ $sharedPath }}/storage"
+       echo "Shared storage directory created"
+   fi
+
+   if [ -f "{{ $sharedPath }}/.env" ]; then
+       echo "Shared .env already exists, left untouched"
+   elif [ -f "{{ $releasePath }}/.env.example" ]; then
+       cp "{{ $releasePath }}/.env.example" "{{ $sharedPath }}/.env"
+       echo "Shared .env created from .env.example"
+   else
+       touch "{{ $sharedPath }}/.env"
+       echo "Empty shared .env created; fill it in before deploying"
+   fi
 @endtask
 
 @task('make:symlinks')
-   echo "Creating symlinks";
+   set -euo pipefail
 
-   # Remove the release storage directory and .env.example before linking the shared ones.
-   if [ -d {{ $releasePath }}/storage ]; then
-       rm -rf {{ $releasePath }}/storage
-   fi
+   echo "Creating symlinks"
 
-   if [ -f {{ $releasePath }}/.env.example ]; then
-       rm -rf {{ $releasePath }}/.env.example
-   fi
+   # Remove the release storage directory and .env files before linking the shared ones.
+   rm -rf "{{ $releasePath }}/storage"
+   rm -f "{{ $releasePath }}/.env" "{{ $releasePath }}/.env.example"
 
-   # Link shared storage and .env into the release
-   ln -s {{ $sharedPath }}/storage {{ $releasePath }}/storage
-   ln -s {{ $sharedPath }}/.env {{ $releasePath }}/.env
+   ln -s "{{ $sharedPath }}/storage" "{{ $releasePath }}/storage"
+   ln -s "{{ $sharedPath }}/.env" "{{ $releasePath }}/.env"
 
-   # Link the storage folder into public
-   cd {{ $releasePath }}
+   cd "{{ $releasePath }}"
    {{ $php }} artisan storage:link
 
-   echo "Release '.env' and 'storage' have been symlinked";
+   echo "Release '.env' and 'storage' have been symlinked"
 @endtask
 
 @task('setup:generate_app_key')
-   echo "Generating app key";
+   set -euo pipefail
 
-   cd {{ $releasePath }}
-   {{ $php }} artisan key:generate
+   if grep -qE '^APP_KEY=.+' "{{ $sharedPath }}/.env"; then
+       echo "APP_KEY already set, left untouched"
+   else
+       echo "Generating app key"
+
+       cd "{{ $releasePath }}"
+       {{ $php }} artisan key:generate
+   fi
 @endtask
 
 @task('make:link_current_release')
-   echo "Creating current symlink";
+   set -euo pipefail
 
-   if [ -L {{ $currentReleasePath }} ]; then
-       rm -rf {{ $currentReleasePath }}
+   echo "Switching the current release"
+
+   if [ -e "{{ $currentReleasePath }}" ] && [ ! -L "{{ $currentReleasePath }}" ]; then
+       echo "{{ $currentReleasePath }} exists and is not a symlink; refusing to replace it."
+       exit 1
    fi
 
-   if [ -d {{ $releasePath }}/current ]; then
-       rm -rf {{ $releasePath }}/current
+   # Atomic switch: build the symlink aside, then rename over the live one.
+   ln -sfn "{{ $releasePath }}" "{{ $currentReleasePath }}.tmp"
+   mv -Tf "{{ $currentReleasePath }}.tmp" "{{ $currentReleasePath }}"
+
+   if [ "$(readlink "{{ $currentReleasePath }}")" != "{{ $releasePath }}" ]; then
+       echo "Current symlink could not be switched"
+       exit 1
    fi
 
-   ln -nfs {{ $releasePath }} {{ $currentReleasePath }}
-
-   if [ ! -L {{ $currentReleasePath }} ]; then
-       echo "Current symlink could not be created";
-       exit 1;
-   fi
-
-   echo "Current release symlink created";
+   echo "Current release switched to {{ $release }}"
 @endtask
 
 @task('setup:finish')
@@ -266,26 +354,28 @@
 @endtask
 
 @task('check_if_release_exists')
-   if [ ! -d {{ $releasesPath }} ]; then
-       echo "Deploy directory does not exist on the server. Run 'envoy run setup' to set up your deployment directory.";
-       exit 1;
+   if [ ! -d "{{ $releasesPath }}" ]; then
+       echo "Deploy directory does not exist on the server. Run 'envoy run setup' to set up your deployment directory."
+       exit 1
    fi
 @endtask
 
 @task('make:app_down')
    @if ($maintenance === true)
-       {{ $php }} {{ $currentReleasePath }}/artisan down
-       echo "App is in maintenance mode";
+       {{ $php }} "{{ $currentReleasePath }}/artisan" down || true
+       echo "App is in maintenance mode"
    @else
-       echo "Application is not in maintenance mode";
+       echo "Application is not in maintenance mode"
    @endif
 @endtask
 
 @task('make:migration', ['on' => $env])
    @if ($migration === true)
+       set -euo pipefail
+
        echo "Running migrations"
 
-       cd {{ $releasePath }}
+       cd "{{ $releasePath }}"
        {{ $php }} artisan migrate --force
 
        echo "Migrations complete"
@@ -296,9 +386,11 @@
 
 @task('make:db_seed', ['on' => $env])
    @if ($seeder === true)
+       set -euo pipefail
+
        echo "Running seeders"
 
-       cd {{ $releasePath }}
+       cd "{{ $releasePath }}"
        {{ $php }} artisan db:seed --force
 
        echo "Database seeding complete"
@@ -308,60 +400,56 @@
 @endtask
 
 @task('make:cache', ['on' => $env])
-   # Clear the cache held by the currently live release
-   cd {{ $currentReleasePath }}
-   {{ $php }} artisan optimize:clear
-   {{ $php }} artisan config:clear
-   {{ $php }} artisan route:clear
-   {{ $php }} artisan view:clear
-   echo "Cache cleared in the current release";
+   set -euo pipefail
 
-   # Warm the cache for the new release
-   cd {{ $releasePath }}
-   {{ $php }} artisan route:cache
-   {{ $php }} artisan view:cache
-   {{ $php }} artisan config:cache
-   echo "New release has been cached";
+   # Only the new release is touched. The live release keeps its caches until the
+   # symlink switch, and the shared application cache store is never cleared here.
+   cd "{{ $releasePath }}"
+   {{ $php }} artisan optimize
+
+   echo "New release caches warmed (config, events, routes, views)"
 @endtask
 
 @task('make:install_octane', ['on' => $env])
    @if ($octaneInstall === true)
-       cd {{ $releasePath }}
+       set -euo pipefail
+
+       cd "{{ $releasePath }}"
        {{ $php }} artisan octane:install --server={{ $octaneServer }} --no-interaction
 
-       echo "Octane installed";
+       echo "Octane installed"
    @else
-       echo "Octane install skipped";
+       echo "Octane install skipped"
    @endif
 @endtask
 
 @task('make:app_up', ['on' => $env])
-   {{ $php }} {{ $currentReleasePath }}/artisan up
-   echo "App is up";
+   {{ $php }} "{{ $currentReleasePath }}/artisan" up
+   echo "App is up"
 @endtask
 
 @task('make:restart_queue', ['on' => $env])
    @if ($queueRestart === true)
-       cd {{ $releasePath }}
+       cd "{{ $currentReleasePath }}"
        {{ $php }} artisan queue:restart
-       echo "Queue restarted";
+       echo "Queue restarted"
    @else
-       echo "Queue restart skipped";
+       echo "Queue restart skipped"
    @endif
 @endtask
 
 @task('make:horizon:terminate', ['on' => $env])
    @if ($horizonTerminate === true)
-       cd {{ $currentReleasePath }}
+       cd "{{ $currentReleasePath }}"
        {{ $php }} artisan horizon:terminate
-       echo "Horizon terminated, it should restart automatically";
+       echo "Horizon terminated, it should restart automatically"
    @else
-       echo "Horizon restart skipped";
+       echo "Horizon restart skipped"
    @endif
 @endtask
 
 @task('make:reload_octane', ['on' => $env])
-   cd {{ $currentReleasePath }}
+   cd "{{ $currentReleasePath }}"
 
    @if ($octaneReload === true)
        if [ $( {{ $php }} artisan octane:status --no-interaction 2>&1 | grep -c 'server is running' ) -gt 0 ]; then
@@ -377,117 +465,153 @@
 @endtask
 
 @task('make:clean_old_release', ['on' => $env])
-   # Keep only the three most recent releases
-   cd {{ $releasesPath }}
+   set -euo pipefail
 
-   for RELEASE in $(ls -1d * | head -n -3); do
-       echo "Deleting old release $RELEASE"
-       rm -rf "$RELEASE"
+   cd "{{ $releasesPath }}"
+
+   CURRENT_TARGET=$(basename "$(readlink "{{ $currentReleasePath }}")")
+
+   # Keep the live release plus the most recent others, prune the rest by age.
+   (ls -1t | grep -vFx "$CURRENT_TARGET" || true) | tail -n +{{ $releasesToKeep }} | while read -r OLD_RELEASE; do
+       echo "Deleting old release $OLD_RELEASE"
+       rm -rf "./$OLD_RELEASE"
    done
 
-   echo "Old releases cleaned up, only the latest 3 releases are kept";
+   echo "Old releases pruned; keeping the current release and the {{ $releasesToKeep - 1 }} most recent others"
 @endtask
 
 @task('make:check_app_health', ['on' => $env])
-   # Verify the application responds with HTTP 200
-   curl -s -o /dev/null -w "%{http_code}" {{ $appUrl }} | grep 200 > /dev/null 2>&1 || (echo "App is down" && exit 1) && echo "App is up and running";
+   ATTEMPTS=5
+
+   for i in $(seq 1 $ATTEMPTS); do
+       STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "{{ $appUrl }}" || echo "000")
+
+       if [ "$STATUS" = "200" ]; then
+           echo "Health check passed (HTTP $STATUS)"
+           exit 0
+       fi
+
+       echo "Health check attempt $i/$ATTEMPTS returned HTTP $STATUS, retrying in 3s"
+       sleep 3
+   done
+
+   echo "App is unhealthy after $ATTEMPTS attempts. The previous release is still on disk:"
+   echo "  envoy run deploy:rollback --env={{ $env }}"
+   exit 1
 @endtask
 
 @task('sentry:release', ['on' => $env])
    @if ((bool) $sentryEnabled === true)
-       echo "Recording release in Sentry";
+       # Best effort: the release is already live, a Sentry hiccup must not fail the deploy.
+       SENTRY_CLI="{{ $sharedPath }}/bin/sentry-cli"
 
-       mkdir -p /tmp/sentry_cli_installation
-       cd /tmp/sentry_cli_installation
-       wget https://github.com/getsentry/sentry-cli/releases/download/2.23.0/sentry-cli-Linux-x86_64 -O sentry-cli --quiet
-       chmod +x sentry-cli
+       if [ ! -x "$SENTRY_CLI" ]; then
+           echo "Installing sentry-cli"
+           mkdir -p "{{ $sharedPath }}/bin"
+           curl -sL https://github.com/getsentry/sentry-cli/releases/download/2.23.0/sentry-cli-Linux-x86_64 -o "$SENTRY_CLI" && chmod +x "$SENTRY_CLI" || echo "sentry-cli installation failed (non-fatal)"
+       fi
 
-       export SENTRY_AUTH_TOKEN="{{ $sentryToken }}"
-       export SENTRY_ORG="{{ $sentryOrg }}"
-       export SENTRY_PROJECT="{{ $sentryProject }}"
-       export VERSION="{{ $sentryVersion }}"
-       export ENVIRONMENT="{{ $env }}"
+       if [ -x "$SENTRY_CLI" ]; then
+           export SENTRY_AUTH_TOKEN="{{ $sentryToken }}"
+           export SENTRY_ORG="{{ $sentryOrg }}"
+           export SENTRY_PROJECT="{{ $sentryProject }}"
 
-       ./sentry-cli releases new -p "$SENTRY_PROJECT" "$VERSION"
-       ./sentry-cli releases deploys "$VERSION" new -e "$ENVIRONMENT" --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" --version "$VERSION"
+           "$SENTRY_CLI" releases new "{{ $sentryVersion }}" && \
+           "$SENTRY_CLI" releases deploys "{{ $sentryVersion }}" new -e "{{ $env }}" && \
+           "$SENTRY_CLI" releases finalize "{{ $sentryVersion }}" && \
+           echo "Sentry release recorded" || echo "Sentry release failed (non-fatal)"
+       fi
 
-       rm -rf /tmp/sentry_cli_installation
+       true
    @else
-       echo "Sentry release skipped";
+       echo "Sentry release skipped"
    @endif
 @endtask
 
 @task('deploy:complete')
    @if (! empty($slackWebhookUrl))
-       curl -X POST -H 'Content-type: application/json' --data '{"text":"{{ $deploymentSuccess }}"}' {{ $slackWebhookUrl }} > /dev/null 2>&1
+       curl -sf -X POST -H 'Content-type: application/json' --data {{ $deploymentSuccessPayload }} "{{ $slackWebhookUrl }}" > /dev/null 2>&1 || true
    @endif
 
-   echo "Deployment complete, live at {{ $appUrl }}";
+   echo "Deployment complete, live at {{ $appUrl }}"
 @endtask
 
 @task('make:rollback', ['on' => $env])
-   echo "Starting rollback process on the {{ $env }} environment";
+   set -euo pipefail
 
-   cd {{ $currentReleasePath }}
-   {{ $php }} artisan down
-   {{ $php }} artisan cache:clear
+   echo "Starting rollback process on the {{ $env }} environment"
 
-   # Resolve the currently linked release
-   current_release=$(readlink {{ $currentReleasePath }})
+   if [ ! -L "{{ $currentReleasePath }}" ]; then
+       echo "No current release symlink found, nothing to roll back from"
+       exit 1
+   fi
 
-   # Find the previous release
-   cd {{ $releasesPath }}
-   prev_release=$(ls -t | grep -v $(basename $current_release) | head -1)
+   CURRENT_TARGET=$(basename "$(readlink "{{ $currentReleasePath }}")")
 
-   if [ -z "$prev_release" ]; then
+   cd "{{ $releasesPath }}"
+   PREV_RELEASE=$( (ls -1t | grep -vFx "$CURRENT_TARGET" || true) | head -1 )
+
+   if [ -z "$PREV_RELEASE" ]; then
        echo "No previous release found to roll back to"
        exit 1
    fi
 
-   # Point current to the previous release
-   rm {{ $currentReleasePath }}
-   ln -s {{ $releasesPath }}/$prev_release {{ $currentReleasePath }}
-   echo "Rolled back to previous release: $prev_release";
+   echo "Rolling back from $CURRENT_TARGET to $PREV_RELEASE"
+
+   # Atomic switch, no maintenance window needed.
+   ln -sfn "{{ $releasesPath }}/$PREV_RELEASE" "{{ $currentReleasePath }}.tmp"
+   mv -Tf "{{ $currentReleasePath }}.tmp" "{{ $currentReleasePath }}"
+
+   echo "Rolled back to previous release: $PREV_RELEASE"
 
    @if($queueRestart === true)
-       cd {{ $currentReleasePath }}
+       cd "{{ $currentReleasePath }}"
        {{ $php }} artisan queue:restart
-       echo "Queue worker restarted";
-   @endif
-
-   @if($octaneReload === true)
-       cd {{ $currentReleasePath }}
-       {{ $php }} artisan octane:reload
-       echo "Laravel Octane reloaded";
+       echo "Queue worker restarted"
    @endif
 
    @if($horizonTerminate === true)
-       cd {{ $currentReleasePath }}
+       cd "{{ $currentReleasePath }}"
        {{ $php }} artisan horizon:terminate
-       echo "Laravel Horizon terminated";
+       echo "Laravel Horizon terminated"
    @endif
 
-   cd {{ $currentReleasePath }}
-   {{ $php }} artisan up
+   @if($octaneReload === true)
+       cd "{{ $currentReleasePath }}"
+       {{ $php }} artisan octane:reload || true
+       echo "Laravel Octane reloaded"
+   @endif
 @endtask
 
 @task('rollback:complete')
    @if (! empty($slackWebhookUrl))
-       curl -X POST -H 'Content-type: application/json' --data '{"text":"{{ $rollbackSuccessMessage }}"}' {{ $slackWebhookUrl }} > /dev/null 2>&1
+       curl -sf -X POST -H 'Content-type: application/json' --data {{ $rollbackSuccessPayload }} "{{ $slackWebhookUrl }}" > /dev/null 2>&1 || true
    @endif
 
-   echo "Rollback complete, live at {{ $appUrl }}";
+   echo "Rollback complete, live at {{ $appUrl }}"
 @endtask
 
 @task('backups:list')
    for dir in "{{ $backupPath }}"/*; do
+       [ -e "$dir" ] || continue
        echo "$(basename "$dir") | $(stat -c '%y' "$dir" | cut -d ' ' -f 1)"
    done
 @endtask
 
 @task('releases:list')
+   CURRENT_TARGET=$(basename "$(readlink "{{ $currentReleasePath }}" 2>/dev/null || echo '')")
+
    for dir in "{{ $releasesPath }}"/*; do
-       echo "$(basename "$dir") | $(stat -c '%y' "$dir" | cut -d ' ' -f 1)"
+       [ -e "$dir" ] || continue
+
+       NAME=$(basename "$dir")
+       MARKER=""
+
+       if [ "$NAME" = "$CURRENT_TARGET" ]; then
+           MARKER=" (current)"
+       fi
+
+       echo "$NAME | $(stat -c '%y' "$dir" | cut -d ' ' -f 1)$MARKER"
    done
 @endtask
 
@@ -496,9 +620,15 @@
 @endsuccess
 
 @error
-   if (empty($failureMessage)) {
-       $failureMessage = "Task $task failed on the $env environment on $appName. Error message: $error";
-   }
+   // Task bodies are captured at parse time, so per-story "set message" tasks can
+   // never work: the failure message must be built here, where $task is known.
+   $failureMessage = "*Task '$task' failed on $appName*
+       - Environment: $env
+       - Strategy: $strategy
+       - Deployment path: $path
+       - SSH host: $sshHost
+       - Date: $date
+       If the deployment lock was left behind, release it with 'envoy run deploy:unlock --env=$env'.";
 
    @slack($slackWebhookUrl, '', $failureMessage)
 

--- a/src/Envoy.blade.php
+++ b/src/Envoy.blade.php
@@ -329,8 +329,15 @@
    echo "Switching the current release"
 
    if [ -e "{{ $currentReleasePath }}" ] && [ ! -L "{{ $currentReleasePath }}" ]; then
-       echo "{{ $currentReleasePath }} exists and is not a symlink; refusing to replace it."
-       exit 1
+       # Server provisioning (e.g. Laravel Forge) often leaves an empty 'current'
+       # directory behind. rmdir only ever removes an empty directory, so a real
+       # deployment can never be deleted here.
+       if rmdir "{{ $currentReleasePath }}" 2>/dev/null; then
+           echo "Removed the empty 'current' directory left over from server provisioning"
+       else
+           echo "{{ $currentReleasePath }} exists, is not a symlink and is not empty; refusing to replace it."
+           exit 1
+       fi
    fi
 
    # Atomic switch: build the symlink aside, then rename over the live one.

--- a/src/Envoy.blade.php
+++ b/src/Envoy.blade.php
@@ -22,6 +22,19 @@
 
 @servers([$env => "{$sshUser}@{$sshHost}"])
 
+@before
+    // Artifact strategy: build the release on this machine and upload it right
+    // before the server extracts it, so `envoy run deploy` is self-contained.
+    if ($task === 'make:extract_artifact' && $strategy === 'artifact') {
+        try {
+            AxaZara\Bankai\ArtifactBuilder::buildAndUpload(getcwd(), $sshUser, $sshHost, $artifactPath);
+        } catch (Throwable $e) {
+            echo 'Artifact build failed: ' . $e->getMessage() . "\n";
+            exit(1);
+        }
+    }
+@endbefore
+
 @story('setup' , ['on' => $env])
     setup:directories
     make:clone_repository
@@ -121,6 +134,8 @@
 @endtask
 
 @task('deploy:acquire_lock')
+   mkdir -p "{{ $artifactsPath }}"
+
    # mkdir is atomic: it either creates the lock or fails because one exists.
    if mkdir "{{ $deployLockPath }}" 2>/dev/null; then
        date '+%Y-%m-%d %H:%M:%S' > "{{ $deployLockPath }}/started_at"
@@ -166,10 +181,7 @@
        set -euo pipefail
 
        if [ ! -s "{{ $artifactPath }}" ]; then
-           echo "No artifact found at {{ $artifactPath }}."
-           echo "Build and upload the release artifact first, for example:"
-           echo "  php artisan bankai:artifact"
-           echo "  scp release.tar.gz {{ $sshUser }}@{{ $sshHost }}:{{ $artifactPath }}"
+           echo "No artifact found at {{ $artifactPath }}; the build-and-upload step did not run or failed."
            exit 1
        fi
 

--- a/src/Providers/BankaiServiceProvider.php
+++ b/src/Providers/BankaiServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace AxaZara\Bankai\Providers;
 
+use AxaZara\Bankai\Console\BankaiArtifact;
 use AxaZara\Bankai\Console\BankaiInstall;
 use Illuminate\Support\ServiceProvider;
 
@@ -12,6 +13,7 @@ class BankaiServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands(commands: [
                 BankaiInstall::class,
+                BankaiArtifact::class,
             ]);
 
             $this->publishes([

--- a/src/Traits/ConfigValidationTrait.php
+++ b/src/Traits/ConfigValidationTrait.php
@@ -42,6 +42,7 @@ trait ConfigValidationTrait
     private function getEnvironmentRules(): array
     {
         return [
+            'strategy'          => 'sometimes|string|in:clone,artifact',
             'branch'            => 'required|string',
             'ssh_host'          => 'required|string',
             'ssh_user'          => 'required|string',
@@ -64,8 +65,9 @@ trait ConfigValidationTrait
     private function getSettingsRules(): array
     {
         return [
-            'repository_url'    => ['required', 'string'],
+            'repository_url'    => 'nullable|string',
             'slack_webhook_url' => 'nullable|url',
+            'releases_to_keep'  => 'sometimes|integer|min:1',
         ];
     }
 

--- a/tests/ArtifactBuilderTest.php
+++ b/tests/ArtifactBuilderTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use AxaZara\Bankai\ArtifactBuilder;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+final class ArtifactBuilderTest extends BaseTestCase
+{
+    private string $sourceDir;
+
+    protected function setUp(): void
+    {
+        $this->sourceDir = sys_get_temp_dir() . '/bankai-builder-fixture-' . uniqid();
+
+        mkdir($this->sourceDir . '/.git', 0755, true);
+        mkdir($this->sourceDir . '/app', 0755, true);
+        mkdir($this->sourceDir . '/storage/logs', 0755, true);
+
+        file_put_contents($this->sourceDir . '/composer.json', '{}');
+        file_put_contents($this->sourceDir . '/artisan', '<?php // stub');
+        file_put_contents($this->sourceDir . '/app/Kernel.php', '<?php // stub');
+        file_put_contents($this->sourceDir . '/.env', 'APP_KEY=secret');
+        file_put_contents($this->sourceDir . '/auth.json', '{}');
+        file_put_contents($this->sourceDir . '/.git/HEAD', 'ref: refs/heads/main');
+    }
+
+    protected function tearDown(): void
+    {
+        exec('rm -rf ' . escapeshellarg($this->sourceDir));
+    }
+
+    public function test_it_builds_a_tarball_with_production_vendor_and_without_sensitive_files(): void
+    {
+        ob_start();
+
+        try {
+            $tarball = (new ArtifactBuilder())->build($this->sourceDir);
+        } finally {
+            ob_end_clean();
+        }
+
+        try {
+            $this->assertFileExists($tarball);
+
+            exec('tar -tzf ' . escapeshellarg($tarball), $entries);
+            $entries = array_map(static fn (string $entry): string => rtrim($entry, '/'), $entries);
+
+            $this->assertContains('./artisan', $entries);
+            $this->assertContains('./app/Kernel.php', $entries);
+            $this->assertContains('./vendor/autoload.php', $entries);
+            $this->assertNotContains('./.env', $entries);
+            $this->assertNotContains('./auth.json', $entries);
+            $this->assertNotContains('./.git', $entries);
+            $this->assertNotContains('./storage', $entries);
+        } finally {
+            @unlink($tarball);
+        }
+    }
+}

--- a/tests/BankaiArtifactTest.php
+++ b/tests/BankaiArtifactTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+class BankaiArtifactTest extends TestCase
+{
+    public function test_it_packages_the_application_without_sensitive_files(): void
+    {
+        $envFile = base_path('.env');
+        $authFile = base_path('auth.json');
+        $output = sys_get_temp_dir() . '/bankai_artifact_test_' . uniqid() . '.tar.gz';
+
+        $envFileExisted = file_exists($envFile);
+
+        if (! $envFileExisted) {
+            file_put_contents($envFile, 'APP_KEY=secret');
+        }
+
+        file_put_contents($authFile, '{"http-basic":{}}');
+
+        try {
+            $this->artisan('bankai:artifact', ['--output' => $output])
+                ->assertExitCode(0);
+
+            $this->assertFileExists($output);
+
+            exec('tar -tzf ' . escapeshellarg($output), $entries);
+            $entries = array_map(static fn (string $entry): string => rtrim($entry, '/'), $entries);
+
+            $this->assertContains('./composer.json', $entries);
+            $this->assertNotContains('./.env', $entries);
+            $this->assertNotContains('./auth.json', $entries);
+            $this->assertNotContains('./.git', $entries);
+        } finally {
+            @unlink($output);
+            @unlink($authFile);
+
+            if (! $envFileExisted) {
+                @unlink($envFile);
+            }
+        }
+    }
+}

--- a/tests/DeploymentConfigTest.php
+++ b/tests/DeploymentConfigTest.php
@@ -67,4 +67,87 @@ class DeploymentConfigTest extends TestCase
 
         new DeploymentConfig('staging');
     }
+
+    public function test_the_strategy_defaults_to_clone(): void
+    {
+        $variables = (new DeploymentConfig('staging'))->extractVariables();
+
+        $this->assertSame('clone', $variables['strategy']);
+    }
+
+    public function test_it_exposes_artifact_lock_and_retention_variables(): void
+    {
+        $variables = (new DeploymentConfig('staging'))->extractVariables();
+
+        $this->assertSame('/var/www/app/artifacts', $variables['artifactsPath']);
+        $this->assertSame('/var/www/app/artifacts/incoming.tar.gz', $variables['artifactPath']);
+        $this->assertSame('/var/www/app/.bankai-deploy.lock', $variables['deployLockPath']);
+        $this->assertSame(3, $variables['releasesToKeep']);
+    }
+
+    public function test_releases_to_keep_is_configurable(): void
+    {
+        config(['bankai.settings.releases_to_keep' => 5]);
+
+        $variables = (new DeploymentConfig('staging'))->extractVariables();
+
+        $this->assertSame(5, $variables['releasesToKeep']);
+    }
+
+    public function test_it_accepts_the_artifact_strategy(): void
+    {
+        config(['bankai.environments.staging.strategy' => 'artifact']);
+
+        $variables = (new DeploymentConfig('staging'))->extractVariables();
+
+        $this->assertSame('artifact', $variables['strategy']);
+    }
+
+    public function test_it_throws_for_an_unknown_strategy(): void
+    {
+        config(['bankai.environments.staging.strategy' => 'teleport']);
+
+        $this->expectException(RuntimeException::class);
+
+        new DeploymentConfig('staging');
+    }
+
+    public function test_the_artifact_strategy_does_not_require_a_repository_url(): void
+    {
+        config([
+            'bankai.environments.staging.strategy' => 'artifact',
+            'bankai.settings.repository_url'       => null,
+        ]);
+
+        $variables = (new DeploymentConfig('staging'))->extractVariables();
+
+        $this->assertNull($variables['repositoryUrl']);
+    }
+
+    public function test_it_rejects_a_repository_url_with_embedded_credentials(): void
+    {
+        config(['bankai.settings.repository_url' => 'https://user:token@github.com/acme/app.git']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('must not embed credentials');
+
+        new DeploymentConfig('staging');
+    }
+
+    public function test_the_repository_url_can_be_overridden_from_the_environment(): void
+    {
+        $_ENV['BANKAI_REPOSITORY_URL'] = 'https://x-access-token:ephemeral@github.com/acme/app.git';
+        $_SERVER['BANKAI_REPOSITORY_URL'] = $_ENV['BANKAI_REPOSITORY_URL'];
+
+        try {
+            $variables = (new DeploymentConfig('staging'))->extractVariables();
+
+            $this->assertSame(
+                'https://x-access-token:ephemeral@github.com/acme/app.git',
+                $variables['repositoryUrl']
+            );
+        } finally {
+            unset($_ENV['BANKAI_REPOSITORY_URL'], $_SERVER['BANKAI_REPOSITORY_URL']);
+        }
+    }
 }

--- a/tests/EnvoyTemplateLoadTest.php
+++ b/tests/EnvoyTemplateLoadTest.php
@@ -130,4 +130,14 @@ final class EnvoyTemplateLoadTest extends BaseTestCase
         $this->assertStringContainsString('ln -sfn', $script);
         $this->assertStringContainsString('mv -Tf', $script);
     }
+
+    public function test_the_template_registers_the_artifact_build_hook(): void
+    {
+        $container = $this->loadedContainer('artifact');
+
+        $this->assertNotEmpty(
+            $container->getBeforeCallbacks(),
+            'The @before hook that builds and uploads the artifact is missing.'
+        );
+    }
 }

--- a/tests/EnvoyTemplateLoadTest.php
+++ b/tests/EnvoyTemplateLoadTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Laravel\Envoy\Compiler;
+use Laravel\Envoy\TaskContainer;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+/**
+ * Loads the shipped Envoy template through Envoy's own TaskContainer, exactly
+ * as `envoy run` does, and asserts that the stories resolve and that the
+ * per-strategy tasks render the right script bodies.
+ */
+final class EnvoyTemplateLoadTest extends BaseTestCase
+{
+    private function loadedContainer(string $strategy): TaskContainer
+    {
+        $container = new TaskContainer();
+
+        $container->load(
+            __DIR__ . '/../src/Envoy.blade.php',
+            new Compiler(),
+            $this->templateVariables($strategy)
+        );
+
+        return $container;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function templateVariables(string $strategy): array
+    {
+        return [
+            'env'                => 'staging',
+            'strategy'           => $strategy,
+            'repositoryUrl'      => 'git@github.com:acme/app.git',
+            'slackWebhookUrl'    => null,
+            'appName'            => "Acme's App",
+            'branch'             => 'main',
+            'sshHost'            => 'staging.example.com',
+            'sshUser'            => 'deploy',
+            'appUrl'             => 'https://staging.example.com',
+            'path'               => '/var/www/app',
+            'php'                => 'php',
+            'composer'           => 'composer',
+            'composerOptions'    => '',
+            'migration'          => true,
+            'seeder'             => false,
+            'queueRestart'       => false,
+            'maintenance'        => false,
+            'octaneInstall'      => false,
+            'octaneReload'       => false,
+            'octaneServer'       => 'swoole',
+            'horizonTerminate'   => false,
+            'releasesToKeep'     => 3,
+            'date'               => '2026-01-01 00:00:00',
+            'release'            => 'staging_20260101_000000',
+            'releasePath'        => '/var/www/app/releases/staging_20260101_000000',
+            'releasesPath'       => '/var/www/app/releases',
+            'sharedPath'         => '/var/www/app/shared',
+            'backupPath'         => '/var/www/app/backups',
+            'currentReleasePath' => '/var/www/app/current',
+            'artifactsPath'      => '/var/www/app/artifacts',
+            'artifactPath'       => '/var/www/app/artifacts/incoming.tar.gz',
+            'deployLockPath'     => '/var/www/app/.bankai-deploy.lock',
+            'sentryEnabled'      => false,
+            'sentryOrg'          => 'acme',
+            'sentryProject'      => 'app',
+            'sentryToken'        => 'secret',
+            'sentryVersion'      => 'staging_20260101_000000',
+        ];
+    }
+
+    public function test_the_deploy_story_contains_the_expected_tasks(): void
+    {
+        $container = $this->loadedContainer('clone');
+
+        $story = $container->getMacro('deploy');
+
+        $this->assertContains('deploy:acquire_lock', $story);
+        $this->assertContains('make:clone_repository', $story);
+        $this->assertContains('make:extract_artifact', $story);
+        $this->assertContains('make:check_app_health', $story);
+        $this->assertContains('deploy:release_lock', $story);
+
+        // The health check must run while the previous release is still on disk.
+        $this->assertLessThan(
+            array_search('make:clean_old_release', $story, true),
+            array_search('make:check_app_health', $story, true)
+        );
+    }
+
+    public function test_the_clone_strategy_renders_git_tasks_and_skips_artifact_tasks(): void
+    {
+        $container = $this->loadedContainer('clone');
+
+        $this->assertStringContainsString('git clone', $container->getTask('make:clone_repository')->script);
+        $this->assertStringContainsString('skipped (clone strategy)', $container->getTask('make:extract_artifact')->script);
+        $this->assertStringContainsString('composer install', $container->getTask('make:install_composer_dependencies')->script);
+    }
+
+    public function test_the_artifact_strategy_renders_extraction_and_skips_git_tasks(): void
+    {
+        $container = $this->loadedContainer('artifact');
+
+        $this->assertStringContainsString('tar -xzf', $container->getTask('make:extract_artifact')->script);
+        $this->assertStringContainsString('skipped (artifact strategy)', $container->getTask('make:clone_repository')->script);
+        $this->assertStringContainsString('artifact ships its vendor directory', $container->getTask('make:install_composer_dependencies')->script);
+    }
+
+    public function test_slack_payloads_survive_quotes_in_the_app_name(): void
+    {
+        $container = $this->loadedContainer('clone');
+
+        $script = $container->getTask('deploy:complete')->script;
+
+        // With no webhook configured the curl is omitted entirely.
+        $this->assertStringNotContainsString('curl', $script);
+    }
+
+    public function test_the_current_release_switch_is_atomic(): void
+    {
+        $container = $this->loadedContainer('clone');
+
+        $script = $container->getTask('make:link_current_release')->script;
+
+        $this->assertStringContainsString('ln -sfn', $script);
+        $this->assertStringContainsString('mv -Tf', $script);
+    }
+}

--- a/tests/EnvoyTemplateLoadTest.php
+++ b/tests/EnvoyTemplateLoadTest.php
@@ -131,6 +131,19 @@ final class EnvoyTemplateLoadTest extends BaseTestCase
         $this->assertStringContainsString('mv -Tf', $script);
     }
 
+    public function test_an_empty_current_directory_is_removed_with_rmdir_only(): void
+    {
+        $container = $this->loadedContainer('clone');
+
+        $script = $container->getTask('make:link_current_release')->script;
+
+        // rmdir fails on non-empty directories, so a real deployment can never
+        // be deleted; anything non-empty must still abort the deploy.
+        $this->assertStringContainsString('rmdir', $script);
+        $this->assertStringNotContainsString('rm -rf "{{ $currentReleasePath }}"', $script);
+        $this->assertStringContainsString('refusing to replace it', $script);
+    }
+
     public function test_the_template_registers_the_artifact_build_hook(): void
     {
         $container = $this->loadedContainer('artifact');


### PR DESCRIPTION
## Summary

Reworks the shipped Envoy pipeline around two deployment strategies and fixes a series of long-standing bugs. Part of the enterprise deployment standardisation (GitHub private repos, secret-free configs).

### Deployment strategies (`strategy` per environment)

- **`artifact` (recommended)** — `vendor/bin/envoy run deploy --env=X` is fully self-contained: a `@before` hook (new `ArtifactBuilder`) builds the release on the Envoy machine in a temporary directory (`composer install --no-dev`, front-end build when present), uploads the tarball over SSH to `{path}/artifacts/incoming.tar.gz`, and the server only extracts it. **No Git access, no Composer credentials, no auth.json needed on servers**, and pipelines need no separate build/scp steps. `bankai:artifact` also exists to package the working directory manually.
- **`clone` (default, backwards compatible)** — existing flow, hardened:
  - `repository_url` with embedded credentials (`https://user:token@…`) is now **rejected** with a clear error;
  - `BANKAI_REPOSITORY_URL` env var can inject an ephemeral token-bearing URL from CI (e.g. GitHub App installation token), never stored on the server.

### Bug fixes

| Bug | Fix |
|---|---|
| `make:cache` ran `optimize:clear` in the **live** release on every deploy, purging the **shared application cache store** (Redis) in production | Only the new release is warmed (`artisan optimize`); live release and shared store untouched |
| `current` symlink switch was delete-then-link (window with no `current`) | Atomic `ln + rename`, with a guard when `current` is a real directory |
| Rollback ran `artisan down` + `cache:clear` **before** checking a previous release exists (could leave the app down, purged shared cache) | Validates first, atomic switch, zero-downtime, no cache purge |
| Release pruning sorted alphabetically and could delete the release `current` points to after a rollback | Sorts by mtime, always excludes the live release, honours new `releases_to_keep` (default 3) |
| Health check ran once, after pruning, with a substring match (`grep 200`) | 5 retries × 3s, strict comparison, runs **before** pruning so an instant rollback target remains |
| Per-story `set:*_failure_message` tasks never worked: task bodies execute at parse time (`ob_start`), so the **last** message in the file always won; `$error` in `@error` was never defined | Failure message is built inside the `@error` handler where `$task` is known |
| Slack notification JSON broke on quotes in app name/messages | Payloads are `json_encode` + `escapeshellarg` quoted |
| Tasks had no fail-fast: a failed `cd` let subsequent commands run in the wrong directory | `set -euo pipefail` + full quoting across server tasks |
| Re-running `setup` overwrote `shared/.env` and regenerated `APP_KEY` | Setup is idempotent (existing .env, storage and APP_KEY preserved) |
| `sentry-cli` was downloaded from GitHub on every deploy into a shared /tmp path; failure after go-live failed the whole deploy | Cached in `shared/bin`, best-effort (non-fatal), adds `releases finalize` |
| `make:npm_install` installed node_modules but never built assets | Replaced by `make:build_assets` (`npm ci`/`yarn --immutable` + `run build` when defined) |
| Concurrent deploys could interleave | Atomic server-side deploy lock + new `deploy:unlock` story |

### Tests

- 28 tests / 400 assertions green (16 new): strategy resolution and validation, credential-URL guard, env override, retention, artifact command exclusions, `ArtifactBuilder` end-to-end build, and `EnvoyTemplateLoadTest` which loads the template through Envoy's own `TaskContainer` and asserts per-strategy script bodies, story composition, health-check ordering and the artifact `@before` hook.

### Breaking changes

- `repository_url` with embedded credentials now throws (rotate the credential and switch to a deploy key or `BANKAI_REPOSITORY_URL`).
- `make:npm_install` renamed to `make:build_assets` (only relevant if a project overrides it).
- `make:cache` no longer clears caches in the live release: projects relying on the implicit shared-store purge must clear it explicitly in `run:after_deploy`.

### Migration notes (existing servers)

- Nothing to do for `clone` projects (default strategy).
- To adopt `artifact`: set `'strategy' => 'artifact'` per environment — the `artifacts/` directory is created automatically at the next deploy.