### PR TITLE
fix(artifact): keep composer auth available during the artifact build

### DIFF
--- a/src/ArtifactBuilder.php
+++ b/src/ArtifactBuilder.php
@@ -74,7 +74,7 @@ class ArtifactBuilder
 
             echo "Packing the release artifact\n";
             $this->runOrFail(
-                ['tar', '--exclude=./node_modules', '-czf', $tarball, '.'],
+                ['tar', '--exclude=./node_modules', '--exclude=./auth.json', '-czf', $tarball, '.'],
                 $buildDir
             );
 
@@ -101,6 +101,13 @@ class ArtifactBuilder
         $command = ['rsync', '-a'];
 
         foreach (self::EXCLUDED_PATHS as $excludedPath) {
+            // auth.json is needed inside the build directory so Composer can
+            // authenticate against private registries; it is excluded from the
+            // final tarball instead, so it never ships to the server.
+            if ($excludedPath === 'auth.json') {
+                continue;
+            }
+
             $command[] = "--exclude=/{$excludedPath}";
         }
 


### PR DESCRIPTION
The artifact build excluded `auth.json` from the project copy, so `composer install --no-dev` inside the build directory could not authenticate against private registries (Repman) on projects that rely on a local `auth.json` instead of the `COMPOSER_AUTH` env var.

The file is now copied into the build directory and excluded from the **tarball** instead: Composer authenticates during the build, and the credential still never ships to the server.

Both auth mechanisms now work for the build: local `auth.json` or `COMPOSER_AUTH`.