### PR TITLE
fix(artifact): honour the environment's composer_options during the build

### DIFF
--- a/src/ArtifactBuilder.php
+++ b/src/ArtifactBuilder.php
@@ -40,11 +40,12 @@ class ArtifactBuilder
         string $sourceDir,
         string $sshUser,
         string $sshHost,
-        string $remoteArtifactPath
+        string $remoteArtifactPath,
+        string $composerOptions = ''
     ): void {
         $builder = new self();
 
-        $tarball = $builder->build($sourceDir);
+        $tarball = $builder->build($sourceDir, $composerOptions);
 
         try {
             $builder->upload($tarball, $sshUser, $sshHost, $remoteArtifactPath);
@@ -53,7 +54,26 @@ class ArtifactBuilder
         }
     }
 
-    public function build(string $sourceDir): string
+    /**
+     * Build the Composer install command from the environment's configured
+     * `composer_options`, mirroring what the clone strategy runs on the server.
+     * An empty option string installs with dev dependencies, exactly as it
+     * would server-side.
+     *
+     * @return list<string>
+     */
+    public static function composerInstallCommand(string $composerOptions): array
+    {
+        $options = preg_split('/\s+/', trim($composerOptions), -1, PREG_SPLIT_NO_EMPTY) ?: [];
+
+        return array_values(array_unique(array_merge(
+            ['composer', 'install'],
+            $options,
+            ['--no-progress', '--no-interaction'],
+        )));
+    }
+
+    public function build(string $sourceDir, string $composerOptions = ''): string
     {
         $buildDir = sys_get_temp_dir() . '/bankai-build-' . uniqid();
         $tarball = sys_get_temp_dir() . '/bankai-artifact-' . uniqid() . '.tar.gz';
@@ -64,11 +84,8 @@ class ArtifactBuilder
             echo "Copying the project to the build directory\n";
             $this->copyProject($sourceDir, $buildDir);
 
-            echo "Installing production dependencies\n";
-            $this->runOrFail(
-                ['composer', 'install', '--no-dev', '--prefer-dist', '--optimize-autoloader', '--no-progress', '--no-interaction'],
-                $buildDir
-            );
+            echo "Installing dependencies (composer install {$composerOptions})\n";
+            $this->runOrFail(self::composerInstallCommand($composerOptions), $buildDir);
 
             $this->buildAssets($buildDir);
 

--- a/src/Envoy.blade.php
+++ b/src/Envoy.blade.php
@@ -27,7 +27,7 @@
     // before the server extracts it, so `envoy run deploy` is self-contained.
     if ($task === 'make:extract_artifact' && $strategy === 'artifact') {
         try {
-            AxaZara\Bankai\ArtifactBuilder::buildAndUpload(getcwd(), $sshUser, $sshHost, $artifactPath);
+            AxaZara\Bankai\ArtifactBuilder::buildAndUpload(getcwd(), $sshUser, $sshHost, $artifactPath, $composerOptions);
         } catch (Throwable $e) {
             echo 'Artifact build failed: ' . $e->getMessage() . "\n";
             exit(1);

--- a/tests/ArtifactBuilderTest.php
+++ b/tests/ArtifactBuilderTest.php
@@ -32,6 +32,30 @@ final class ArtifactBuilderTest extends BaseTestCase
         exec('rm -rf ' . escapeshellarg($this->sourceDir));
     }
 
+    public function test_the_composer_command_uses_the_configured_environment_options(): void
+    {
+        $this->assertSame(
+            ['composer', 'install', '--no-dev', '--prefer-dist', '--optimize-autoloader', '--no-progress', '--no-interaction'],
+            ArtifactBuilder::composerInstallCommand('--no-dev --prefer-dist --optimize-autoloader')
+        );
+    }
+
+    public function test_empty_composer_options_install_with_dev_dependencies(): void
+    {
+        $this->assertSame(
+            ['composer', 'install', '--no-progress', '--no-interaction'],
+            ArtifactBuilder::composerInstallCommand('')
+        );
+    }
+
+    public function test_duplicate_composer_options_are_deduplicated(): void
+    {
+        $this->assertSame(
+            ['composer', 'install', '--no-dev', '--no-progress', '--no-interaction'],
+            ArtifactBuilder::composerInstallCommand('--no-dev --no-progress --no-interaction')
+        );
+    }
+
     public function test_it_builds_a_tarball_with_production_vendor_and_without_sensitive_files(): void
     {
         ob_start();


### PR DESCRIPTION
`ArtifactBuilder` hardcoded `composer install --no-dev --prefer-dist --optimize-autoloader`, ignoring the `composer_options` configured per environment.

The build now mirrors exactly what the clone strategy runs server-side (`make:install_composer_dependencies`): the environment's `composer_options` are used verbatim, with `--no-progress --no-interaction` appended (deduplicated). An empty option string installs with dev dependencies, as it always did on staging servers.

The `@before` hook passes `$composerOptions` through `buildAndUpload()`. Covered by three new unit tests on `composerInstallCommand()`.