### PR TITLE
fix(octane): stop the master on rollback and fix the deploy ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,49 @@ vendor/bin/envoy run deploy --env={your-environment}
 
 Point your web server at the `current/public` directory. For example, with [Laravel Forge](https://forge.laravel.com/) you should set your site's web directory to `current/public`. The `current` symlink always points to the latest release.
 
+## Laravel Octane
+
+Enabling `octane.reload` does **not** run `octane:reload`. Reloading only recycles
+the workers of the running master, and that master is booted from the release
+directory it was started in (`base_path()` is resolved from `__FILE__`, after the
+symlink has been dereferenced). It would keep serving the old code forever.
+
+Bankai stops the master instead and lets your process manager respawn it, so the
+new process re-resolves `current` and picks up the new release. This requires a
+correctly configured process manager, otherwise the application simply stays down
+until the health check fails.
+
+**Supervisor program (Octane, Horizon and queue workers alike):**
+
+```ini
+[program:app-octane]
+command=php /var/www/your-app/current/artisan octane:start --server=swoole --host=127.0.0.1 --port=8000
+directory=/var/www/your-app/current   ; never point this at a release directory
+autostart=true
+autorestart=true                      ; not 'unexpected': a clean octane:stop exits 0
+user=your-user
+```
+
+With `autorestart=unexpected` and `exitcodes=0`, Supervisor treats the clean exit
+of `octane:stop` as normal and never restarts the process.
+
+Two more constraints:
+
+- **`storage/` must stay shared.** Octane writes its server state file under
+  `storage/logs`, which is how a command run from the new release can stop the
+  master started by the old one. Un-sharing `storage/` breaks this silently.
+- **`artisan down` does not cover the restart window.** Once the master is dead,
+  Nginx gets a connection refused and returns a raw 502, not Laravel's maintenance
+  page. If you want a clean page, serve it from the web server:
+
+  ```nginx
+  error_page 502 503 504 /maintenance.html;
+  location = /maintenance.html {
+      root /var/www/your-app/shared/public;
+      internal;
+  }
+  ```
+
 ## Lifecycle hooks
 
 Bankai exposes three hooks you can define in your `Envoy.blade.php`:

--- a/README.md
+++ b/README.md
@@ -297,6 +297,11 @@ Quickly revert to the previous release (atomic symlink switch, no maintenance wi
 vendor/bin/envoy run deploy:rollback --env={your-environment}
 ```
 
+The rollback is also the recovery path for a deploy that died halfway through: it
+restarts the queue workers, Horizon and Octane on the restored release, lifts the
+maintenance mode a failed deploy may have left behind, and health checks the
+result before reporting success.
+
 ## Deployment lock
 
 At the start of every deploy, Bankai atomically creates a lock directory on the

--- a/src/Envoy.blade.php
+++ b/src/Envoy.blade.php
@@ -80,6 +80,7 @@
 @story('deploy:rollback', ['on' => $env])
     make:rollback
     run:after_rollback
+    make:app_up
     make:check_app_health
     rollback:complete
 @endstory
@@ -444,6 +445,9 @@
 @endtask
 
 @task('make:app_up', ['on' => $env])
+   # Deliberately unconditional: a deploy that failed after 'make:app_down' leaves
+   # the maintenance flag behind in the shared storage, so the rollback has to be
+   # able to clear it whatever the environment's own 'maintenance' setting is.
    {{ $php }} "{{ $currentReleasePath }}/artisan" up
    echo "App is up"
 @endtask
@@ -482,7 +486,12 @@
            echo "Octane is running, stopping the master of the old release"
 
            if ! {{ $php }} artisan octane:stop --no-interaction; then
+               # Failing here is deliberate. The old master is very likely still alive
+               # and would keep serving the previous code against an already migrated
+               # database, so the app must stay down until a human has looked at it.
                echo "Octane could not be stopped; the new release will not be served."
+               echo "The app is left down on purpose. Restore the previous release with:"
+               echo "  envoy run deploy:rollback --env={{ $env }}"
                exit 1
            fi
 

--- a/src/Envoy.blade.php
+++ b/src/Envoy.blade.php
@@ -66,10 +66,10 @@
     make:cache
     run:after_deploy
     make:link_current_release
-    make:app_up
     make:restart_queue
     make:horizon:terminate
     make:reload_octane
+    make:app_up
     make:check_app_health
     make:clean_old_release
     deploy:release_lock
@@ -80,6 +80,7 @@
 @story('deploy:rollback', ['on' => $env])
     make:rollback
     run:after_rollback
+    make:check_app_health
     rollback:complete
 @endstory
 
@@ -471,10 +472,21 @@
    cd "{{ $currentReleasePath }}"
 
    @if ($octaneReload === true)
-       if [ $( {{ $php }} artisan octane:status --no-interaction 2>&1 | grep -c 'server is running' ) -gt 0 ]; then
-           echo "Octane is running. Stopping it in the old release; supervisor will restart it in the new release."
-           {{ $php }} artisan octane:stop --no-interaction
-           echo "Octane stopped in the old release"
+       # Reloading would only recycle the workers of the running master, which still
+       # lives in the old release directory (base_path() is resolved from __FILE__ at
+       # boot, after symlink dereferencing). Stopping the master is the only way to get
+       # the new code served: the process manager respawns it and it re-resolves
+       # 'current'. octane:status exits 0 when a server is running, 1 otherwise;
+       # the exit code is more stable across Octane versions than its output.
+       if {{ $php }} artisan octane:status --no-interaction > /dev/null 2>&1; then
+           echo "Octane is running, stopping the master of the old release"
+
+           if ! {{ $php }} artisan octane:stop --no-interaction; then
+               echo "Octane could not be stopped; the new release will not be served."
+               exit 1
+           fi
+
+           echo "Octane stopped, the process manager will restart it on the new release"
        else
            echo "Octane is not running, skipping restart."
        fi
@@ -497,6 +509,14 @@
    done
 
    echo "Old releases pruned; keeping the current release and the {{ $releasesToKeep - 1 }} most recent others"
+
+   # Compiled view filenames are hashed from the view's absolute path, so every
+   # release writes a brand new set into the shared storage and nothing ever
+   # removes the previous ones. Prune the entries no release has touched in a month.
+   if [ -d "{{ $sharedPath }}/storage/framework/views" ]; then
+       find "{{ $sharedPath }}/storage/framework/views" -type f -name '*.php' -mtime +30 -delete 2>/dev/null || true
+       echo "Compiled views older than 30 days pruned from the shared storage"
+   fi
 @endtask
 
 @task('make:check_app_health', ['on' => $env])
@@ -514,7 +534,7 @@
        sleep 3
    done
 
-   echo "App is unhealthy after $ATTEMPTS attempts. The previous release is still on disk:"
+   echo "App is unhealthy after $ATTEMPTS attempts. Previous releases are still on disk:"
    echo "  envoy run deploy:rollback --env={{ $env }}"
    exit 1
 @endtask
@@ -597,8 +617,21 @@
 
    @if($octaneReload === true)
        cd "{{ $currentReleasePath }}"
-       {{ $php }} artisan octane:reload || true
-       echo "Laravel Octane reloaded"
+
+       # Same reasoning as 'make:reload_octane': reloading would only recycle the
+       # workers of a master still running from the release we are leaving.
+       if {{ $php }} artisan octane:status --no-interaction > /dev/null 2>&1; then
+           echo "Octane is running, stopping the master of the rolled back release"
+
+           if ! {{ $php }} artisan octane:stop --no-interaction; then
+               echo "Octane could not be stopped; the rolled back release will not be served."
+               exit 1
+           fi
+
+           echo "Octane stopped, the process manager will restart it on the rolled back release"
+       else
+           echo "Octane is not running, skipping restart."
+       fi
    @endif
 @endtask
 

--- a/tests/EnvoyTemplateLoadTest.php
+++ b/tests/EnvoyTemplateLoadTest.php
@@ -15,14 +15,17 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
  */
 final class EnvoyTemplateLoadTest extends BaseTestCase
 {
-    private function loadedContainer(string $strategy): TaskContainer
+    /**
+     * @param array<string, mixed> $overrides
+     */
+    private function loadedContainer(string $strategy, array $overrides = []): TaskContainer
     {
         $container = new TaskContainer();
 
         $container->load(
             __DIR__ . '/../src/Envoy.blade.php',
             new Compiler(),
-            $this->templateVariables($strategy)
+            array_merge($this->templateVariables($strategy), $overrides)
         );
 
         return $container;
@@ -91,6 +94,58 @@ final class EnvoyTemplateLoadTest extends BaseTestCase
             array_search('make:clean_old_release', $story, true),
             array_search('make:check_app_health', $story, true)
         );
+
+        // Octane only serves the new code once its master has been restarted, so the
+        // app must stay down until then: bringing it up earlier would serve the old
+        // code against an already migrated database.
+        $this->assertLessThan(
+            array_search('make:app_up', $story, true),
+            array_search('make:reload_octane', $story, true)
+        );
+
+        $this->assertLessThan(
+            array_search('make:check_app_health', $story, true),
+            array_search('make:app_up', $story, true)
+        );
+    }
+
+    public function test_the_rollback_story_health_checks_the_restored_release(): void
+    {
+        $container = $this->loadedContainer('clone');
+
+        $story = $container->getMacro('deploy:rollback');
+
+        $this->assertContains('make:check_app_health', $story);
+
+        $this->assertLessThan(
+            array_search('rollback:complete', $story, true),
+            array_search('make:check_app_health', $story, true)
+        );
+    }
+
+    public function test_octane_is_stopped_rather_than_reloaded_on_deploy_and_rollback(): void
+    {
+        $container = $this->loadedContainer('clone', ['octaneReload' => true]);
+
+        foreach (['make:reload_octane', 'make:rollback'] as $task) {
+            $script = $container->getTask($task)->script;
+
+            // 'octane:reload' recycles the workers of a master still booted from the
+            // release being left behind, so it would keep serving the old code.
+            $this->assertStringNotContainsString('octane:reload', $script);
+            $this->assertStringContainsString('octane:stop', $script);
+            $this->assertStringContainsString('octane:status --no-interaction > /dev/null 2>&1', $script);
+        }
+    }
+
+    public function test_stale_compiled_views_are_pruned_from_the_shared_storage(): void
+    {
+        $container = $this->loadedContainer('clone');
+
+        $script = $container->getTask('make:clean_old_release')->script;
+
+        $this->assertStringContainsString('/var/www/app/shared/storage/framework/views', $script);
+        $this->assertStringContainsString('-mtime +30 -delete', $script);
     }
 
     public function test_the_clone_strategy_renders_git_tasks_and_skips_artifact_tasks(): void

--- a/tests/EnvoyTemplateLoadTest.php
+++ b/tests/EnvoyTemplateLoadTest.php
@@ -123,6 +123,30 @@ final class EnvoyTemplateLoadTest extends BaseTestCase
         );
     }
 
+    public function test_the_rollback_story_clears_the_maintenance_mode(): void
+    {
+        // A deploy that failed after 'make:app_down' leaves the maintenance flag in
+        // the shared storage. The rollback is the recovery path, so it has to lift it,
+        // and it has to do so before the release is health checked.
+        $container = $this->loadedContainer('clone');
+
+        $story = $container->getMacro('deploy:rollback');
+
+        $this->assertContains('make:app_up', $story);
+
+        $this->assertLessThan(
+            array_search('make:check_app_health', $story, true),
+            array_search('make:app_up', $story, true)
+        );
+    }
+
+    public function test_the_app_is_brought_up_regardless_of_the_maintenance_setting(): void
+    {
+        $container = $this->loadedContainer('clone', ['maintenance' => false]);
+
+        $this->assertStringContainsString('artisan" up', $container->getTask('make:app_up')->script);
+    }
+
     public function test_octane_is_stopped_rather_than_reloaded_on_deploy_and_rollback(): void
     {
         $container = $this->loadedContainer('clone', ['octaneReload' => true]);


### PR DESCRIPTION
## Contexte

Revue du `Envoy.blade.php` : deux angles morts Octane, plus trois points secondaires.

## Bug 1 — le rollback ne rollback pas

`deploy:rollback` lançait `octane:reload`. Reload ne fait que recycler les workers du master en cours, et ce master est booté depuis la release qu'on quitte (`base_path()` est résolu via `__FILE__`, donc après déréférencement du symlink). Résultat : le symlink bascule, le message « Rolled back » s'affiche, et l'ancien code continue d'être servi. Le `|| true` masquait en plus toute erreur.

Le rollback applique désormais la même logique que le deploy : `octane:stop`, le gestionnaire de processus respawn, le nouveau master re-résout `current`.

## Bug 2 — `make:app_up` trop tôt

`make:app_up` tournait juste après la bascule du symlink, donc avant le redémarrage d'Octane. Entre les deux, on servait l'ancien code contre une base déjà migrée. Il passe après `make:reload_octane`, avant le health check.

## Points secondaires

- `octane:status` est testé par code retour (0 si un serveur tourne) au lieu d'un `grep` sur la chaîne `server is running`, qui n'est pas stable entre versions d'Octane. Vérifié dans `laravel/octane` 2.x : `StatusCommand::handle()` retourne `! $isRunning`.
- Le health check est ajouté à la story `deploy:rollback` : on rollback parfois vers une release qui ne survit pas au schéma de base déjà migré.
- `shared/storage/framework/views` gonflait indéfiniment (le nom du fichier compilé est un hash du chemin absolu de la vue, donc chaque release en écrit un jeu complet). `make:clean_old_release` purge les entrées de plus de 30 jours.
- README : section Octane documentant les prérequis côté serveur (`directory=` sur `current`, `autorestart=true` et pas `unexpected`, `storage/` obligatoirement partagé, `error_page 502 503 504` côté Nginx puisqu'`artisan down` ne couvre pas la fenêtre où le master est mort).

## Tests

4 nouvelles assertions/tests dans `EnvoyTemplateLoadTest` : ordre `reload_octane` → `app_up` → `check_app_health`, health check dans la story de rollback, absence d'`octane:reload` dans les deux tâches, purge des vues compilées.

```
OK (35 tests, 422 assertions)
```