### PR TITLE
fix(config): name the config block a validation failure came from

### DIFF
--- a/src/Envoy.blade.php
+++ b/src/Envoy.blade.php
@@ -691,7 +691,11 @@
        - Date: $date
        If the deployment lock was left behind, release it with 'envoy run deploy:unlock --env=$env'.";
 
-   @slack($slackWebhookUrl, '', $failureMessage)
+   // Not Envoy's own slack directive: it posts unconditionally, so a deployment
+   // that fails with no webhook configured raises a notification error on top of
+   // the real one. Slack::send() no-ops on a null or empty URL, matching the
+   // emptiness guard the two success notification paths already carry.
+   \AxaZara\Bankai\Slack::send($failureMessage, $slackWebhookUrl);
 
    echo "Envoy task has failed";
 @enderror

--- a/src/Traits/ConfigValidationTrait.php
+++ b/src/Traits/ConfigValidationTrait.php
@@ -21,7 +21,7 @@ trait ConfigValidationTrait
         ];
 
         foreach ($configurations as $configKey => $rules) {
-            $this->validate((array) $this->getConfig($configKey), $rules);
+            $this->validate((array) $this->getConfig($configKey), $rules, $configKey);
         }
     }
 
@@ -30,12 +30,15 @@ trait ConfigValidationTrait
         return config($key);
     }
 
-    private function validate(array $data, array $rules): void
+    private function validate(array $data, array $rules, string $configKey): void
     {
         $validator = Validator::make($data, $rules);
 
         if ($validator->fails()) {
-            throw new \RuntimeException('Validation error: ' . $validator->errors());
+            // Name the config block: on its own, a message like
+            // {"token":["The token field is required."]} gives no clue which of
+            // the three validated blocks failed, let alone which key to set.
+            throw new \RuntimeException("Invalid configuration for [{$configKey}]: " . $validator->errors());
         }
     }
 

--- a/tests/DeploymentConfigTest.php
+++ b/tests/DeploymentConfigTest.php
@@ -59,6 +59,31 @@ class DeploymentConfigTest extends TestCase
         new DeploymentConfig('staging');
     }
 
+    public function test_a_validation_failure_names_the_config_block_at_fault(): void
+    {
+        config([
+            'bankai.sentry.enabled' => true,
+            'bankai.sentry.token'   => '',
+        ]);
+
+        // On its own, {"token":["The token field is required."]} gives no clue
+        // which of the three validated blocks failed, nor which key to set.
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid configuration for [bankai.sentry]');
+
+        new DeploymentConfig('staging');
+    }
+
+    public function test_the_named_block_points_at_the_environment_that_failed(): void
+    {
+        config(['bankai.environments.staging.ssh_host' => null]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid configuration for [bankai.environments.staging]');
+
+        new DeploymentConfig('staging');
+    }
+
     public function test_it_throws_for_an_invalid_octane_server(): void
     {
         config(['bankai.environments.staging.octane.server' => 'not-a-server']);

--- a/tests/EnvoyCompilationTest.php
+++ b/tests/EnvoyCompilationTest.php
@@ -77,4 +77,23 @@ final class EnvoyCompilationTest extends BaseTestCase
 
         $this->assertFalse($open, 'Compiled template ended with an unterminated <?php block.');
     }
+
+    public function test_the_failure_notification_goes_through_the_guarded_slack_helper(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../src/Envoy.blade.php');
+
+        // Envoy's @slack directive posts unconditionally, so a failed deployment
+        // with no webhook configured raises a notification error on top of the
+        // real one -- exactly when the real one needs to be readable.
+        $this->assertStringNotContainsString(
+            '@slack(',
+            $source,
+            "The @error handler must not use Envoy's @slack directive; use AxaZara\\Bankai\\Slack::send(), which no-ops on an empty webhook.",
+        );
+
+        $this->assertStringContainsString(
+            '\AxaZara\Bankai\Slack::send($failureMessage, $slackWebhookUrl);',
+            $source,
+        );
+    }
 }


### PR DESCRIPTION
Both fixes come out of a real production deploy failure on `axazara/wallet-api` ([run 30768801770](https://github.com/axazara/wallet-api/actions/runs/30768801770/job/91552274030)).

## 1. A validation failure did not say what failed

The whole output of the failed deploy was:

```
Validation error: {"token":["The token field is required."]}
```

`validateConfiguration()` validates three blocks in a row — `bankai.environments.{env}`, `bankai.settings`, `bankai.sentry` — and the message named none of them. There is no way to read that line and know `token` meant `bankai.sentry.token`, fed by `BANKAI_SENTRY_TOKEN`. It took opening the package source to find out, and it cost a failed production deploy plus a wrong first fix in the consuming project.

`$configKey` is already in the loop; it was just dropped on the way to the exception.

```php
- private function validate(array $data, array $rules): void
+ private function validate(array $data, array $rules, string $configKey): void
  ...
- throw new \RuntimeException('Validation error: ' . $validator->errors());
+ throw new \RuntimeException("Invalid configuration for [{$configKey}]: " . $validator->errors());
```

Now:

```
Invalid configuration for [bankai.sentry]: {"token":["The token field is required."]}
```

The rule itself is unchanged. Failing fast on an inconsistent config is right; the message just had to say which config.

## 2. The failure notification had no emptiness guard

The two success paths guard themselves:

```blade
@if (! empty($slackWebhookUrl))
    curl -sf ... "{{ $slackWebhookUrl }}" ... || true
@endif
```

The `@error` handler did not:

```blade
@slack($slackWebhookUrl, '', $failureMessage)
```

Envoy's directive posts unconditionally. With no webhook configured, a failed deployment fires a POST at an empty URL and risks burying the real error behind a notification error — precisely when the real error is the thing you need to read.

It now goes through `AxaZara\Bankai\Slack::send()`, which already no-ops on a null or empty URL, is already covered by `SlackTest`, and was — until this commit — dead code referenced nowhere in `src/`.

## Tests

Three regression tests added, 40 passing (37 before):

- `test_a_validation_failure_names_the_config_block_at_fault`
- `test_the_named_block_points_at_the_environment_that_failed`
- `test_the_failure_notification_goes_through_the_guarded_slack_helper`

`composer sniff` clean. `composer analyse` clean at `--memory-limit=2G` (see below).

## Two pre-existing issues found while working, not touched here

- **`composer analyse` crashes at the default memory limit** on `main`, before any change: `Child process error: PHPStan process crashed because it reached [the memory limit]`. It passes with `--memory-limit=2G`. Worth putting that flag in the `analyse` script the way `wallet-api` does, otherwise the check is failing silently for everyone.
- **The test suite leaves a compiled `Envoy<hash>.php` in the repository root** and `.gitignore` has no rule for it, so it shows up as untracked after every `composer test` and is one `git add -A` away from being committed.