### PR TITLE
ci(release): drop the slash from the release-please component name

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,7 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "package-name": "axazara/bankai",
+      "package-name": "bankai",
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,
       "bump-minor-pre-major": false,


### PR DESCRIPTION
## Release automation has been broken since v2.0.2

Both release-please runs since that tag failed. `fix(artifact)` (#27) and `fix(octane)` (#29) are on `main` and were never released, and #30 would have joined them.

```
✖ Error when creating branch
✖ RequestError [HttpError]: Error creating Pull Request: Reference update failed
   body: '{"ref":"refs/heads/release-please--branches--main--components--axazara/bankai", ...}'
```

## Root cause

release-please derives its branch name from the component, which defaults to `package-name`:

```
release-please--branches--main--components--axazara/bankai
                                             ^^^^^^^^^^^^^
```

The `branch-and-commit-conventions` ruleset excludes `refs/heads/release-please--**`. But `**` in a GitHub ruleset `ref_name` condition matches a **single path segment** — it does not cross a slash. The `/` in `axazara/bankai` pushed the branch out of the exclusion, so `branch_name_pattern` applied and rejected the ref.

Confirmed with the read-only rules API, `GET /repos/axazara/bankai/rules/branches/{branch}`:

| Branch | Rules applied |
|---|---|
| `release-please--foo` | none (excluded) |
| `release-please--foo/bar` | `branch_name_pattern` |
| `release-please--branches--main--components--axazara/bankai` | `branch_name_pattern` |
| `release-please--branches--main--components--bankai` | none (excluded) |

## The fix

Drop the vendor prefix from `package-name`, so the branch stays inside the exclusion.

The tag is unaffected: `include-component-in-tag` is `false`, so releases remain `vX.Y.Z`. Only the release-PR branch name and the changelog heading change.

## Separate problem, not fixed here

The same `**` behaviour breaks the `refs/heads/dependabot/**` exclusion in that ruleset:

| Branch | Rules applied |
|---|---|
| `dependabot/foo` | none (excluded) |
| `dependabot/composer/brick/money-0.9` | `branch_name_pattern` |

Composer dependency branches carry a `vendor/name` segment, so real Dependabot branches land in the second row and cannot be created. That is a ruleset change, not a repository change, so it is out of scope for this PR — but it needs fixing, otherwise Dependabot is silently dead on this repo.